### PR TITLE
Standardize code formatting across F# codebase

### DIFF
--- a/src/Imperium.Web/Program.fs
+++ b/src/Imperium.Web/Program.fs
@@ -8,17 +8,18 @@ open Microsoft.Extensions.Logging
 let main args =
     let builder = WebApplication.CreateBuilder(args)
     builder.Logging.AddConsole() |> ignore
-    
+
     let app = builder.Build()
-    
+
     let logger = app.Services.GetRequiredService<ILogger<obj>>()
-    app.Services.GetRequiredService<IHostApplicationLifetime>()
-        .ApplicationStarted
-        .Register(fun () -> logger.LogInformation("Web application Imperium started")) |> ignore
+
+    app.Services
+        .GetRequiredService<IHostApplicationLifetime>()
+        .ApplicationStarted.Register(fun () -> logger.LogInformation("Web application Imperium started"))
+    |> ignore
 
     app.MapGet("/", Func<string>(fun () -> "Hello Imperium!")) |> ignore
-    
-    app.Run()
-    
-    0 // Exit code
 
+    app.Run()
+
+    0 // Exit code

--- a/src/Imperium/Accounting.fsi
+++ b/src/Imperium/Accounting.fsi
@@ -5,4 +5,4 @@ module Accounting =
     // Public API will be added here as the module evolves.
 
     /// Placeholder to make module valid - will be removed when public API is added.
-    val internal placeholder : unit
+    val internal placeholder: unit

--- a/src/Imperium/Contract.fs
+++ b/src/Imperium/Contract.fs
@@ -8,10 +8,15 @@ module Accounting =
     open Imperium.Primitives
 
     // Commands
-    
+
     /// Charge a nation for rondel movement.
     type ChargeNationForRondelMovement = ChargeNationForRondelMovementCommand -> Result<unit, string>
-    and ChargeNationForRondelMovementCommand = { GameId: Guid; Nation: string; Amount: Amount; BillingId: Guid }
+
+    and ChargeNationForRondelMovementCommand =
+        { GameId: Guid
+          Nation: string
+          Amount: Amount
+          BillingId: Guid }
 
     /// Void a previously initiated rondel charge before payment completion.
     type VoidRondelCharge = VoidRondelChargeCommand -> Result<unit, string>
@@ -22,11 +27,12 @@ module Accounting =
     type AccountingEvent =
         | RondelInvoicePaid of RondelInvoicePaid
         | RondelInvoicePaymentFailed of RondelInvoicePaymentFailed
-    /// Invoice payment succeeded. 
+
+    /// Invoice payment succeeded.
     and RondelInvoicePaid = { GameId: Guid; BillingId: Guid }
-    /// Invoice payment failed due to insufficient funds or validation error. 
+    /// Invoice payment failed due to insufficient funds or validation error.
     and RondelInvoicePaymentFailed = { GameId: Guid; BillingId: Guid }
-        
+
 module Rondel =
     open System
 
@@ -38,7 +44,11 @@ module Rondel =
 
     /// Move a nation to a rondel space. Determines cost and may invoke Accounting dependency.
     type Move = MoveCommand -> Result<unit, string>
-    and MoveCommand = { GameId: Guid; Nation: string; Space: string }
+
+    and MoveCommand =
+        { GameId: Guid
+          Nation: string
+          Space: string }
 
     // Events
     /// Integration events published by Rondel bounded context to inform other domains of Rondel movement changes.
@@ -46,12 +56,21 @@ module Rondel =
         | PositionedAtStart of PositionedAtStart
         | ActionDetermined of ActionDetermined
         | MoveToActionSpaceRejected of MoveToActionSpaceRejected
+
     /// Nations positioned at starting positions, rondel ready for movement commands.
     and PositionedAtStart = { GameId: Guid }
+
     /// Nation successfully moved to a space and the corresponding action was determined.
-    and ActionDetermined = { GameId: Guid; Nation: string; Action: string }
+    and ActionDetermined =
+        { GameId: Guid
+          Nation: string
+          Action: string }
+
     /// Nation's movement rejected due to payment failure.
-    and MoveToActionSpaceRejected = { GameId: Guid; Nation: string; Space: string }
+    and MoveToActionSpaceRejected =
+        { GameId: Guid
+          Nation: string
+          Space: string }
 
 module Gameplay =
     // Placeholder module for future Gameplay contract types.

--- a/src/Imperium/Gameplay.fsi
+++ b/src/Imperium/Gameplay.fsi
@@ -6,4 +6,4 @@ module Gameplay =
     // Public API will be added here as the module evolves.
 
     /// Placeholder to make module valid - will be removed when public API is added.
-    val internal placeholder : unit
+    val internal placeholder: unit

--- a/src/Imperium/Primitives.fs
+++ b/src/Imperium/Primitives.fs
@@ -9,7 +9,7 @@ module Id =
         if guid = Guid.Empty then
             Error "Id cannot be Guid.Empty."
         else
-            Ok (Id guid)
+            Ok(Id guid)
 
     let createMap mapper guid = create guid |> Result.map mapper
 
@@ -35,14 +35,13 @@ type Amount = private Amount of int<M>
 
 module Amount =
     [<RequireQualifiedAccess>]
-    type Error =
-        | NegativeAmount of string
+    type Error = NegativeAmount of string
 
     let create (millions: int) =
         if millions < 0 then
             Error "Amount cannot be negative (millions)."
         else
-            Ok (Amount(millions * 1<M>))
+            Ok(Amount(millions * 1<M>))
 
     let unsafe (millions: int) = Amount(millions * 1<M>)
     let value (Amount v) = int v
@@ -73,7 +72,7 @@ module Decision =
     let map (f: 'a -> 'b) (pipeline: Decision<'a, 'outcome>) =
         match pipeline with
         | Resolve outcome -> Resolve outcome
-        | Continue state -> Continue (f state)
+        | Continue state -> Continue(f state)
 
     /// Merge both cases when they contain the same type
     let resolve (continueToOutcome: 'a -> 'outcome) (decision: Decision<'a, 'outcome>) : 'outcome =

--- a/src/Imperium/Rondel.fs
+++ b/src/Imperium/Rondel.fs
@@ -29,6 +29,7 @@ module Rondel =
         | Maneuver
         | Taxation
         | Factory
+
     module Action =
         let toString action =
             match action with
@@ -49,24 +50,27 @@ module Rondel =
         | Factory
         | ProductionTwo
         | ManeuverTwo
+
     module Space =
-        let private spacesInOrder = [|
-            Space.Investor
-            Space.Import
-            Space.ProductionOne
-            Space.ManeuverOne
-            Space.Taxation
-            Space.Factory
-            Space.ProductionTwo
-            Space.ManeuverTwo
-        |]
+        let private spacesInOrder =
+            [| Space.Investor
+               Space.Import
+               Space.ProductionOne
+               Space.ManeuverOne
+               Space.Taxation
+               Space.Factory
+               Space.ProductionTwo
+               Space.ManeuverTwo |]
+
         let distance fromSpace toSpace =
             let fromIndex = Array.findIndex ((=) fromSpace) spacesInOrder
             let toIndex = Array.findIndex ((=) toSpace) spacesInOrder
+
             if toIndex >= fromIndex then
                 toIndex - fromIndex
             else
                 (Array.length spacesInOrder - fromIndex) + toIndex
+
         let toString space =
             match space with
             | Space.Investor -> "Investor"
@@ -77,6 +81,7 @@ module Rondel =
             | Space.Factory -> "Factory"
             | Space.ProductionTwo -> "ProductionTwo"
             | Space.ManeuverTwo -> "ManeuverTwo"
+
         let fromString (s: string) : Result<Space, string> =
             match s with
             | "Investor" -> Ok Space.Investor
@@ -88,12 +93,15 @@ module Rondel =
             | "ProductionTwo" -> Ok Space.ProductionTwo
             | "ManeuverTwo" -> Ok Space.ManeuverTwo
             | _ -> Error $"Invalid rondel space: {s}"
+
         let toAction space =
             match space with
             | Space.Investor -> Action.Investor
             | Space.Import -> Action.Import
-            | Space.ProductionOne | Space.ProductionTwo -> Action.Production
-            | Space.ManeuverOne | Space.ManeuverTwo -> Action.Maneuver
+            | Space.ProductionOne
+            | Space.ProductionTwo -> Action.Production
+            | Space.ManeuverOne
+            | Space.ManeuverTwo -> Action.Maneuver
             | Space.Taxation -> Action.Taxation
             | Space.Factory -> Action.Factory
 
@@ -101,22 +109,34 @@ module Rondel =
     type RondelCommand =
         | StartingPositions of SetToStartingPositions
         | Move of Move
+
     and SetToStartingPositions = { GameId: Id; Nations: Set<string> }
-    and Move = { GameId: Id; Nation: string; Space: Space }
-    module SetToStartingPositions =   
-        let toDomain (command : SetToStartingPositionsCommand) =
+
+    and Move =
+        { GameId: Id
+          Nation: string
+          Space: Space }
+
+    module SetToStartingPositions =
+        let toDomain (command: SetToStartingPositionsCommand) =
             Id.create command.GameId
             |> Result.map (fun id ->
-                { GameId = id; Nations = Set.ofArray command.Nations })
+                { GameId = id
+                  Nations = Set.ofArray command.Nations })
+
     module Move =
-        let toDomain (command : MoveCommand) =
+        let toDomain (command: MoveCommand) =
             Id.create command.GameId
             |> Result.bind (fun id -> Space.fromString command.Space |> Result.map (fun space -> id, space))
-            |> Result.map (fun (id, space) -> { GameId = id; Nation = command.Nation; Space = space })
+            |> Result.map (fun (id, space) ->
+                { GameId = id
+                  Nation = command.Nation
+                  Space = space })
 
     type RondelInboundEvent =
         | RondelInvoicePaid of RondelInvoicePaid
         | RondelInvoicePaymentFailed of RondelInvoicePaymentFailed
+
     type RondelOutboundCommand =
         | ChargeNationForRondelMovement of ChargeNationForRondelMovementCommand
         | VoidRondelCharge of VoidRondelChargeCommand
@@ -124,12 +144,15 @@ module Rondel =
     // State DTOs for persistence
     module Dto =
 
-        type RondelState = {
-            GameId: Guid
-            NationPositions: Map<string, string option>
-            PendingMovements: Map<string, PendingMovement>
-        }
-        and PendingMovement = { Nation: string; TargetSpace: string; BillingId: Guid }
+        type RondelState =
+            { GameId: Guid
+              NationPositions: Map<string, string option>
+              PendingMovements: Map<string, PendingMovement> }
+
+        and PendingMovement =
+            { Nation: string
+              TargetSpace: string
+              BillingId: Guid }
 
     // Public API types
     type LoadRondelState = Guid -> Dto.RondelState option
@@ -146,47 +169,56 @@ module Rondel =
         : Result<unit, string> =
 
         let canNotSetStartPositionsWithNoNations command =
-            if Set.isEmpty command.Nations then Error "Cannot initialize rondel with zero nations." else Ok command
+            if Set.isEmpty command.Nations then
+                Error "Cannot initialize rondel with zero nations."
+            else
+                Ok command
 
-        let execute state (command : SetToStartingPositions) =
+        let execute state (command: SetToStartingPositions) =
             match state with
-            | Some _ -> None, [], []// Already initialized, no-op
+            | Some _ -> None, [], [] // Already initialized, no-op
             | None ->
-                let newState : Dto.RondelState = {
-                    GameId = command.GameId |> Id.value
-                    NationPositions = command.Nations |> Set.toSeq |> Seq.map (fun n -> n, None) |> Map.ofSeq
-                    PendingMovements = Map.empty
-                } 
-                let positionedAtStartEvent = PositionedAtStart { GameId = command.GameId |> Id.value }
-                Some newState, [positionedAtStartEvent], []
+                let newState: Dto.RondelState =
+                    { GameId = command.GameId |> Id.value
+                      NationPositions = command.Nations |> Set.toSeq |> Seq.map (fun n -> n, None) |> Map.ofSeq
+                      PendingMovements = Map.empty }
+
+                let positionedAtStartEvent =
+                    PositionedAtStart { GameId = command.GameId |> Id.value }
+
+                Some newState, [ positionedAtStartEvent ], []
 
         let performIO state events commands =
             let saveState state =
                 match state with
-                | Some s -> save s 
-                | None -> Ok ()
+                | Some s -> save s
+                | None -> Ok()
+
             let publishEvents events = events |> List.iter publish |> Ok
+
             let executeOutboundCommands commands =
-                let executeCommand = function
-                    | ChargeNationForRondelMovement c -> Ok ()
-                    | VoidRondelCharge c -> Ok () 
-                (Ok (), commands)
-                ||> List.fold (fun state cmd ->
-                    state |> Result.bind (fun () -> executeCommand cmd))
+                let executeCommand =
+                    function
+                    | ChargeNationForRondelMovement c -> Ok()
+                    | VoidRondelCharge c -> Ok()
+
+                (Ok(), commands)
+                ||> List.fold (fun state cmd -> state |> Result.bind (fun () -> executeCommand cmd))
+
             saveState state
             |> Result.bind (fun () -> publishEvents events)
             |> Result.bind (fun () -> executeOutboundCommands commands)
             |> Result.defaultWith (fun e -> failwith $"Failed to perform IO side effects: {e}")
 
-        command 
-        |> SetToStartingPositions.toDomain 
-        |> Result.bind canNotSetStartPositionsWithNoNations 
+        command
+        |> SetToStartingPositions.toDomain
+        |> Result.bind canNotSetStartPositionsWithNoNations
         |> Result.map (fun cmd -> load (cmd.GameId |> Id.value), cmd)
         |> Result.map (fun (state, cmd) -> execute state cmd)
         |> Result.map (fun (state, events, commands) -> performIO state events commands)
 
     type MoveOutcome =
-        | Rejected of rejectedCommand : Move
+        | Rejected of rejectedCommand: Move
         | Free of targetSpace: Space * nation: string
         | FreeWithSupersedingUnpaidMovement of targetSpace: Space * nation: string
         | Paid of targetSpace: Space * distance: int * nation: string
@@ -200,102 +232,199 @@ module Rondel =
         (voidCharge: VoidRondelCharge)
         (command: MoveCommand)
         : Result<unit, string> =
-            let noMovesAllowedIfNotInitialized (state, validatedCommand) =
+        let noMovesAllowedIfNotInitialized (state, validatedCommand) =
+            match state with
+            | None -> Resolve(Rejected validatedCommand)
+            | Some s -> Continue(s, validatedCommand)
+
+        let noMovesAllowedForNationNotInGame (rondelState: Dto.RondelState, validatedCommand) =
+            match rondelState.NationPositions |> Map.tryFind validatedCommand.Nation with
+            | None -> Resolve(Rejected validatedCommand)
+            | Some possibleNationPosition -> Continue(rondelState, validatedCommand, possibleNationPosition)
+
+        let firstMoveIsFreeToAnyPosition (rondelState, validatedCommand, possibleNationPosition) =
+            match possibleNationPosition with
+            | None -> Resolve(Free(validatedCommand.Space, validatedCommand.Nation))
+            | Some currentNationPosition -> Continue(rondelState, validatedCommand, currentNationPosition)
+
+        let failIfPositionIsInvalid (rondelState, validatedCommand, currentNationPosition) =
+            match Space.fromString currentNationPosition with
+            | Ok space -> Continue(rondelState, validatedCommand, space)
+            | Error e -> failwith $"Invalid nation position in state. {e}"
+
+        let decideMovementOutcome (rondelState: Dto.RondelState, validatedCommand, currentNationPosition) =
+            let distance = Space.distance currentNationPosition validatedCommand.Space
+
+            let hasPendingMovement =
+                rondelState.PendingMovements |> Map.containsKey validatedCommand.Nation
+
+            match distance with
+            | 0 -> Rejected validatedCommand
+            | 1
+            | 2
+            | 3 ->
+                if hasPendingMovement then
+                    FreeWithSupersedingUnpaidMovement(validatedCommand.Space, validatedCommand.Nation)
+                else
+                    Free(validatedCommand.Space, validatedCommand.Nation)
+            | 4
+            | 5
+            | 6 ->
+                if hasPendingMovement then
+                    PaidWithSupersedingUnpaidMovement(validatedCommand.Space, distance, validatedCommand.Nation)
+                else
+                    Paid(validatedCommand.Space, distance, validatedCommand.Nation)
+            | _ -> Rejected validatedCommand
+
+        let handleMoveOutcome
+            (state: Dto.RondelState option)
+            (outcome: MoveOutcome)
+            : Dto.RondelState option * RondelEvent list * RondelOutboundCommand list =
+            match outcome, state with
+            | Rejected rejectedCommand, _ ->
+                None,
+                [ MoveToActionSpaceRejected
+                      { GameId = rejectedCommand.GameId |> Id.value
+                        Nation = rejectedCommand.Nation
+                        Space = rejectedCommand.Space |> Space.toString } ],
+                []
+            | Free(targetSpace, nation), Some state ->
+                let newState =
+                    { state with
+                        NationPositions = state.NationPositions |> Map.add nation (Some(Space.toString targetSpace)) }
+
+                let actionDeterminedEvent =
+                    ActionDetermined
+                        { GameId = state.GameId
+                          Nation = nation
+                          Action = targetSpace |> Space.toAction |> Action.toString }
+
+                Some newState, [ actionDeterminedEvent ], []
+            | FreeWithSupersedingUnpaidMovement(targetSpace, nation), Some state ->
+                let newState =
+                    { state with
+                        NationPositions = state.NationPositions |> Map.add nation (Some(Space.toString targetSpace))
+                        PendingMovements = state.PendingMovements |> Map.remove nation }
+
+                let actionDeterminedEvent =
+                    ActionDetermined
+                        { GameId = state.GameId
+                          Nation = nation
+                          Action = targetSpace |> Space.toAction |> Action.toString }
+
+                let existingUnpaidMove = state.PendingMovements |> Map.find nation
+
+                let existingUnpaidMoveRejectedEvent =
+                    MoveToActionSpaceRejected
+                        { GameId = state.GameId
+                          Nation = nation
+                          Space = existingUnpaidMove.TargetSpace }
+
+                let voidChargeCommand =
+                    { GameId = state.GameId
+                      BillingId = existingUnpaidMove.BillingId }
+                    : VoidRondelChargeCommand
+
+                Some newState,
+                [ actionDeterminedEvent; existingUnpaidMoveRejectedEvent ],
+                [ VoidRondelCharge voidChargeCommand ]
+            | Paid(targetSpace, distance, nation), Some state ->
+                let billingId = Guid.NewGuid()
+
+                let newPendingMove =
+                    { TargetSpace = Space.toString targetSpace
+                      Nation = nation
+                      BillingId = billingId }
+                    : Dto.PendingMovement
+
+                let newState =
+                    { state with
+                        PendingMovements = state.PendingMovements |> Map.add nation newPendingMove }
+
+                let amount = (distance - 3) * 2 |> Amount.unsafe
+
+                let chargeCommand =
+                    { GameId = state.GameId
+                      Nation = nation
+                      Amount = amount
+                      BillingId = billingId }
+
+                Some newState, [], [ ChargeNationForRondelMovement chargeCommand ]
+            | PaidWithSupersedingUnpaidMovement(targetSpace, distance, nation), Some state ->
+                let billingId = Guid.NewGuid()
+
+                let newPendingMove =
+                    { TargetSpace = Space.toString targetSpace
+                      Nation = nation
+                      BillingId = billingId }
+                    : Dto.PendingMovement
+
+                let newState =
+                    { state with
+                        PendingMovements = state.PendingMovements |> Map.add nation newPendingMove }
+
+                let amount = (distance - 3) * 2 |> Amount.unsafe
+
+                let chargeCommand =
+                    { GameId = state.GameId
+                      Nation = nation
+                      Amount = amount
+                      BillingId = billingId }
+
+                let existingUnpaidMove = state.PendingMovements |> Map.find nation
+
+                let existingUnpaidMoveRejectedEvent =
+                    MoveToActionSpaceRejected
+                        { GameId = state.GameId
+                          Nation = nation
+                          Space = existingUnpaidMove.TargetSpace }
+
+                let voidChargeCommand =
+                    { GameId = state.GameId
+                      BillingId = existingUnpaidMove.BillingId }
+                    : VoidRondelChargeCommand
+
+                Some newState,
+                [ existingUnpaidMoveRejectedEvent ],
+                [ VoidRondelCharge voidChargeCommand
+                  ChargeNationForRondelMovement chargeCommand ]
+            | _, _ -> failwith "Unhandled move outcome."
+
+        let performIO state events commands =
+            let saveState state =
                 match state with
-                | None -> Resolve (Rejected validatedCommand)
-                | Some s -> Continue (s, validatedCommand)
-            let noMovesAllowedForNationNotInGame (rondelState : Dto.RondelState, validatedCommand) =
-                match rondelState.NationPositions |> Map.tryFind validatedCommand.Nation with
-                | None -> Resolve (Rejected validatedCommand)
-                | Some possibleNationPosition -> Continue (rondelState, validatedCommand, possibleNationPosition)
-            let firstMoveIsFreeToAnyPosition (rondelState, validatedCommand, possibleNationPosition) =
-                match possibleNationPosition with
-                | None -> Resolve (Free (validatedCommand.Space, validatedCommand.Nation))
-                | Some currentNationPosition -> Continue (rondelState, validatedCommand, currentNationPosition)
-            let failIfPositionIsInvalid (rondelState, validatedCommand, currentNationPosition) =
-                match Space.fromString currentNationPosition with
-                | Ok space -> Continue (rondelState, validatedCommand, space)
-                | Error e -> failwith $"Invalid nation position in state. {e}"
-            let decideMovementOutcome (rondelState : Dto.RondelState, validatedCommand, currentNationPosition) =
-                let distance = Space.distance currentNationPosition validatedCommand.Space
-                let hasPendingMovement = rondelState.PendingMovements |> Map.containsKey validatedCommand.Nation
-                match distance with
-                | 0 -> Rejected validatedCommand
-                | 1 | 2 | 3 ->
-                    if hasPendingMovement then
-                        FreeWithSupersedingUnpaidMovement (validatedCommand.Space, validatedCommand.Nation)
-                    else
-                        Free (validatedCommand.Space, validatedCommand.Nation)
-                | 4 | 5 | 6 ->
-                    if hasPendingMovement then
-                        PaidWithSupersedingUnpaidMovement (validatedCommand.Space, distance, validatedCommand.Nation)
-                    else
-                        Paid (validatedCommand.Space, distance, validatedCommand.Nation)
-                | _ -> Rejected validatedCommand
-            let handleMoveOutcome (state: Dto.RondelState option) (outcome : MoveOutcome) : Dto.RondelState option * RondelEvent list * RondelOutboundCommand list =
-                match outcome, state with
-                | Rejected rejectedCommand, _ ->
-                    None, [MoveToActionSpaceRejected { GameId = rejectedCommand.GameId |> Id.value; Nation = rejectedCommand.Nation; Space = rejectedCommand.Space |> Space.toString }], []
-                | Free (targetSpace, nation), Some state ->
-                    let newState = { state with NationPositions = state.NationPositions |> Map.add nation (Some (Space.toString targetSpace)) }
-                    let actionDeterminedEvent = ActionDetermined { GameId = state.GameId; Nation = nation; Action = targetSpace |> Space.toAction |> Action.toString }
-                    Some newState, [actionDeterminedEvent], []
-                | FreeWithSupersedingUnpaidMovement (targetSpace, nation), Some state ->
-                    let newState = { state with NationPositions = state.NationPositions |> Map.add nation (Some (Space.toString targetSpace)); PendingMovements = state.PendingMovements |> Map.remove nation }
-                    let actionDeterminedEvent = ActionDetermined { GameId = state.GameId; Nation = nation; Action = targetSpace |> Space.toAction |> Action.toString }
-                    let existingUnpaidMove = state.PendingMovements |> Map.find nation
-                    let existingUnpaidMoveRejectedEvent = MoveToActionSpaceRejected { GameId = state.GameId; Nation = nation; Space = existingUnpaidMove.TargetSpace }
-                    let voidChargeCommand = { GameId = state.GameId; BillingId = existingUnpaidMove.BillingId } : VoidRondelChargeCommand
-                    Some newState, [actionDeterminedEvent; existingUnpaidMoveRejectedEvent], [VoidRondelCharge voidChargeCommand]
-                | Paid (targetSpace, distance, nation), Some state ->
-                    let billingId = Guid.NewGuid()
-                    let newPendingMove = { TargetSpace = Space.toString targetSpace; Nation = nation; BillingId = billingId } : Dto.PendingMovement
-                    let newState = { state with PendingMovements = state.PendingMovements |> Map.add nation newPendingMove }
-                    let amount = (distance - 3) * 2 |> Amount.unsafe
-                    let chargeCommand = { GameId = state.GameId; Nation = nation; Amount = amount; BillingId = billingId }
-                    Some newState, [], [ChargeNationForRondelMovement chargeCommand]
-                | PaidWithSupersedingUnpaidMovement (targetSpace, distance, nation), Some state ->
-                    let billingId = Guid.NewGuid()
-                    let newPendingMove = { TargetSpace = Space.toString targetSpace; Nation = nation; BillingId = billingId } : Dto.PendingMovement
-                    let newState = { state with PendingMovements = state.PendingMovements |> Map.add nation newPendingMove }
-                    let amount = (distance - 3) * 2 |> Amount.unsafe
-                    let chargeCommand = { GameId = state.GameId; Nation = nation; Amount = amount; BillingId = billingId }
-                    let existingUnpaidMove = state.PendingMovements |> Map.find nation
-                    let existingUnpaidMoveRejectedEvent = MoveToActionSpaceRejected { GameId = state.GameId; Nation = nation; Space = existingUnpaidMove.TargetSpace }
-                    let voidChargeCommand = { GameId = state.GameId; BillingId = existingUnpaidMove.BillingId } : VoidRondelChargeCommand
-                    Some newState, [existingUnpaidMoveRejectedEvent], [VoidRondelCharge voidChargeCommand; ChargeNationForRondelMovement chargeCommand]
-                | _, _ -> failwith "Unhandled move outcome."
-            let performIO state events commands =
-                let saveState state =
-                    match state with
-                    | Some s -> save s 
-                    | None -> Ok ()
-                let publishEvents events = events |> List.iter publish |> Ok
-                let executeOutboundCommands commands =
-                    let executeCommand = function
-                        | ChargeNationForRondelMovement c -> chargeForMovement c 
-                        | VoidRondelCharge c -> voidCharge c
-                    (Ok (), commands)
-                    ||> List.fold (fun state cmd ->
-                        state |> Result.bind (fun () -> executeCommand cmd))
-                saveState state
-                |> Result.bind (fun () -> publishEvents events)
-                |> Result.bind (fun () -> executeOutboundCommands commands)
-                |> Result.defaultWith (fun e -> failwith $"Failed to perform IO side effects: {e}")
+                | Some s -> save s
+                | None -> Ok()
 
-            let execute state command =
-                noMovesAllowedIfNotInitialized (state, command)
-                |> Decision.bind noMovesAllowedForNationNotInGame
-                |> Decision.bind firstMoveIsFreeToAnyPosition
-                |> Decision.bind failIfPositionIsInvalid
-                |> Decision.resolve decideMovementOutcome
-                |> handleMoveOutcome state
-                |||> performIO 
+            let publishEvents events = events |> List.iter publish |> Ok
 
-            command
-            |> Move.toDomain
-            |> Result.map (fun cmd -> load (cmd.GameId |> Id.value), cmd)
-            |> Result.bind (fun (loadedState, cmd) -> Ok (execute loadedState cmd))
+            let executeOutboundCommands commands =
+                let executeCommand =
+                    function
+                    | ChargeNationForRondelMovement c -> chargeForMovement c
+                    | VoidRondelCharge c -> voidCharge c
+
+                (Ok(), commands)
+                ||> List.fold (fun state cmd -> state |> Result.bind (fun () -> executeCommand cmd))
+
+            saveState state
+            |> Result.bind (fun () -> publishEvents events)
+            |> Result.bind (fun () -> executeOutboundCommands commands)
+            |> Result.defaultWith (fun e -> failwith $"Failed to perform IO side effects: {e}")
+
+        let execute state command =
+            noMovesAllowedIfNotInitialized (state, command)
+            |> Decision.bind noMovesAllowedForNationNotInGame
+            |> Decision.bind firstMoveIsFreeToAnyPosition
+            |> Decision.bind failIfPositionIsInvalid
+            |> Decision.resolve decideMovementOutcome
+            |> handleMoveOutcome state
+            |||> performIO
+
+        command
+        |> Move.toDomain
+        |> Result.map (fun cmd -> load (cmd.GameId |> Id.value), cmd)
+        |> Result.bind (fun (loadedState, cmd) -> Ok(execute loadedState cmd))
 
 
     // Event handler: Process successful invoice payment from Accounting domain
@@ -309,24 +438,29 @@ module Rondel =
         let performIO state events =
             let saveState state =
                 match state with
-                | Some s -> save s 
-                | None -> Ok ()
+                | Some s -> save s
+                | None -> Ok()
+
             let publishEvents events = events |> List.iter publish |> Ok
+
             saveState state
             |> Result.bind (fun () -> publishEvents events)
             |> Result.defaultWith (fun e -> failwith $"Failed to perform IO side effects: {e}")
 
-        let failIfNotInitialized (state : Dto.RondelState option, event : RondelInvoicePaid) =
+        let failIfNotInitialized (state: Dto.RondelState option, event: RondelInvoicePaid) =
             match state with
             | Some s -> (s, event)
             | None -> failwith "Rondel not initialized for game."
-        let registerPaymentAndCompleteMovement (state : Dto.RondelState, event : RondelInvoicePaid) =
+
+        let registerPaymentAndCompleteMovement (state: Dto.RondelState, event: RondelInvoicePaid) =
             let billingId = event.BillingId
+
             let pendingMovement =
                 state.PendingMovements
                 |> Map.toSeq
                 |> Seq.tryFind (fun (_, pm) -> pm.BillingId = billingId)
                 |> Option.map snd
+
             match pendingMovement with
             | None ->
                 // No pending movement found for this BillingId - event is ignored for idempotency.
@@ -337,11 +471,23 @@ module Rondel =
                     Space.fromString pending.TargetSpace
                     |> Result.map (Space.toAction >> Action.toString)
                     |> Result.defaultWith (fun parseError ->
-                        failwith $"State corruption: invalid TargetSpace '{pending.TargetSpace}' for pending movement. GameId: {state.GameId}, Nation: {pending.Nation}, Error: {parseError}")
+                        failwith
+                            $"State corruption: invalid TargetSpace '{pending.TargetSpace}' for pending movement. GameId: {state.GameId}, Nation: {pending.Nation}, Error: {parseError}")
+
                 let newNationPosition = Some pending.TargetSpace
-                let newState = { state with NationPositions = state.NationPositions |> Map.add pending.Nation newNationPosition; PendingMovements = state.PendingMovements |> Map.remove pending.Nation }
-                let actionDeterminedEvent = ActionDetermined { GameId = state.GameId; Nation = pending.Nation; Action = action }
-                Some newState, [actionDeterminedEvent]
+
+                let newState =
+                    { state with
+                        NationPositions = state.NationPositions |> Map.add pending.Nation newNationPosition
+                        PendingMovements = state.PendingMovements |> Map.remove pending.Nation }
+
+                let actionDeterminedEvent =
+                    ActionDetermined
+                        { GameId = state.GameId
+                          Nation = pending.Nation
+                          Action = action }
+
+                Some newState, [ actionDeterminedEvent ]
 
         let execute state event =
             failIfNotInitialized (state, event)
@@ -349,8 +495,8 @@ module Rondel =
             ||> performIO
 
         let loadedState = load (event.GameId)
-        Ok (execute loadedState event)
-        
+        Ok(execute loadedState event)
+
     // Event handler: Process failed invoice payment from Accounting domain
     let onInvoicePaymentFailed
         (load: LoadRondelState)

--- a/src/Imperium/Rondel.fsi
+++ b/src/Imperium/Rondel.fsi
@@ -9,14 +9,16 @@ module Rondel =
     // State DTOs for persistence
     module Dto =
         /// A movement pending payment confirmation from Accounting domain.
-
         /// Rondel state for a game - tracks nation positions and pending movements.
-        type RondelState = {
-            GameId: Guid
-            NationPositions: Map<string, string option>
-            PendingMovements: Map<string, PendingMovement>
-        }
-        and PendingMovement = { Nation: string; TargetSpace: string; BillingId: Guid }
+        type RondelState =
+            { GameId: Guid
+              NationPositions: Map<string, string option>
+              PendingMovements: Map<string, PendingMovement> }
+
+        and PendingMovement =
+            { Nation: string
+              TargetSpace: string
+              BillingId: Guid }
 
     // Dependency function types
 
@@ -39,15 +41,23 @@ module Rondel =
     /// Command: Move a nation to the specified space on the rondel.
     /// Determines movement cost and charges via injected Accounting dependency.
     /// Integration event ActionDetermined published based on payment requirement.
-    val move: LoadRondelState -> SaveRondelState -> PublishRondelEvent -> ChargeNationForRondelMovement -> VoidRondelCharge -> Move
+    val move:
+        LoadRondelState ->
+        SaveRondelState ->
+        PublishRondelEvent ->
+        ChargeNationForRondelMovement ->
+        VoidRondelCharge ->
+            Move
 
     // Event handlers
 
     /// Event handler: Processes invoice payment confirmation from Accounting domain.
     /// Completes the nation's movement and publishes ActionDetermined integration event.
     /// If no pending movement exists for the BillingId, the event is ignored (idempotent behavior).
-    val onInvoicedPaid: LoadRondelState -> SaveRondelState -> PublishRondelEvent -> RondelInvoicePaid -> Result<unit, string>
+    val onInvoicedPaid:
+        LoadRondelState -> SaveRondelState -> PublishRondelEvent -> RondelInvoicePaid -> Result<unit, string>
 
     /// Event handler: Processes invoice payment failure from Accounting domain.
     /// Rejects the movement and publishes MoveToActionSpaceRejected integration event.
-    val onInvoicePaymentFailed: LoadRondelState -> SaveRondelState -> PublishRondelEvent -> RondelInvoicePaymentFailed -> Result<unit, string>
+    val onInvoicePaymentFailed:
+        LoadRondelState -> SaveRondelState -> PublishRondelEvent -> RondelInvoicePaymentFailed -> Result<unit, string>

--- a/tests/Imperium.UnitTests/GameplayTests.fs
+++ b/tests/Imperium.UnitTests/GameplayTests.fs
@@ -5,6 +5,8 @@ open Imperium.Gameplay
 
 [<Tests>]
 let tests =
-    testList "Gameplay" [
+    testList
+        "Gameplay"
+        [
         // Tests for public Gameplay API will go here
-    ]
+        ]

--- a/tests/Imperium.UnitTests/Main.fs
+++ b/tests/Imperium.UnitTests/Main.fs
@@ -4,9 +4,5 @@ open Expecto
 
 [<EntryPoint>]
 let main args =
-    let allTests =
-        testList "AllTests" [
-            Gameplay.tests
-            Rondel.tests
-        ]
+    let allTests = testList "AllTests" [ Gameplay.tests; Rondel.tests ]
     runTestsWithCLIArgs [] args allTests

--- a/tests/Imperium.UnitTests/RondelTests.fs
+++ b/tests/Imperium.UnitTests/RondelTests.fs
@@ -8,13 +8,16 @@ open Imperium.Contract.Rondel
 // Test helpers for mock dependencies
 let createMockStore () =
     let store = System.Collections.Generic.Dictionary<Guid, Dto.RondelState>()
+
     let load (gameId: Guid) : Dto.RondelState option =
         match store.TryGetValue(gameId) with
         | true, state -> Some state
         | false, _ -> None
+
     let save (state: Dto.RondelState) : Result<unit, string> =
         store.[state.GameId] <- state
-        Ok ()
+        Ok()
+
     load, save
 
 let createMockPublisher () =
@@ -23,17 +26,23 @@ let createMockPublisher () =
     publish, publishedEvents
 
 let createMockCommandDispatcher () =
-    let dispatchedCommands = ResizeArray<Imperium.Contract.Accounting.ChargeNationForRondelMovementCommand>()
+    let dispatchedCommands =
+        ResizeArray<Imperium.Contract.Accounting.ChargeNationForRondelMovementCommand>()
+
     let chargeForMovement (command: Imperium.Contract.Accounting.ChargeNationForRondelMovementCommand) =
         dispatchedCommands.Add command
-        Ok ()
+        Ok()
+
     chargeForMovement, dispatchedCommands
 
 let createMockVoidCharge () =
-    let voidedCommands = ResizeArray<Imperium.Contract.Accounting.VoidRondelChargeCommand>()
+    let voidedCommands =
+        ResizeArray<Imperium.Contract.Accounting.VoidRondelChargeCommand>()
+
     let voidCharge (command: Imperium.Contract.Accounting.VoidRondelChargeCommand) =
         voidedCommands.Add command
-        Ok ()
+        Ok()
+
     voidCharge, voidedCommands
 
 let spaceToAction (space: string) : string =
@@ -42,540 +51,1025 @@ let spaceToAction (space: string) : string =
     | "Factory" -> "Factory"
     | "Import" -> "Import"
     | "Taxation" -> "Taxation"
-    | "ProductionOne" | "ProductionTwo" -> "Production"
-    | "ManeuverOne" | "ManeuverTwo" -> "Maneuver"
+    | "ProductionOne"
+    | "ProductionTwo" -> "Production"
+    | "ManeuverOne"
+    | "ManeuverTwo" -> "Maneuver"
     | _ -> failwith $"Unknown rondel space: {space}"
 
 [<Tests>]
-let tests = 
-    testList "Rondel" [
-        // Tests for public Rondel API 
-        testList "starting positions" [
-            testCase "starting positions: requires a game id" <| fun _ ->
-                let load, save = createMockStore ()
-                let publish, _ = createMockPublisher ()
-                let command = { GameId = Guid.Empty; Nations = [|"France"|] }
-                let result = setToStartingPositions load save publish command
-                Expect.isError result "starting positions cannot be chosen without a game id"
-            testCase "starting positions: requires at least one nation" <| fun _ ->
-                let load, save = createMockStore ()
-                let publish, _ = createMockPublisher ()
-                let command = { GameId = Guid.NewGuid (); Nations = [||] }
-                let result = setToStartingPositions load save publish command
-                Expect.isError result "starting positions require at least one nation"
-            testCase "starting positions: ignores duplicate nations" <| fun _ ->
-                let load, save = createMockStore ()
-                let publish, publishedEvents = createMockPublisher ()
-                let command = { GameId = Guid.NewGuid (); Nations = [|"France"; "France"|] }
-                let result = setToStartingPositions load save publish command
-                Expect.isOk result "starting positions accept the roster (duplicates ignored)"
-                Expect.isNonEmpty publishedEvents "the rondel should signal that starting positions are set"
-                Expect.contains publishedEvents (PositionedAtStart { GameId = command.GameId }) "the rondel should signal that starting positions are set"
-            testCase "starting positions: signals setup for the roster" <| fun _ ->
-                let load, save = createMockStore ()
-                let publish, publishedEvents = createMockPublisher ()
-                let command = { GameId = Guid.NewGuid (); Nations = [|"France"; "Germany"|] }
-                let result = setToStartingPositions load save publish command
-                Expect.isOk result "starting positions should be accepted"
-                Expect.isNonEmpty publishedEvents "the rondel should signal that starting positions are set"
-                Expect.contains publishedEvents (PositionedAtStart { GameId = command.GameId }) "the rondel should signal that starting positions are set"
-            testCase "starting positions: setting twice does not signal again" <| fun _ ->
-                let load, save = createMockStore ()
-                let publish, publishedEvents = createMockPublisher ()
-                let command = { GameId = Guid.NewGuid (); Nations = [|"France"; "Germany"|] }
-                // First call to set positions
-                let _ = setToStartingPositions load save publish command
-                publishedEvents.Clear ()
-                // Second call to set positions again
-                let result = setToStartingPositions load save publish command
-                Expect.isOk result "setting starting positions twice should not fail"
-                let positionedAtStartPublishedEvents = publishedEvents |> Seq.filter (function | PositionedAtStart _ -> true | _ -> false) |> Seq.toList
-                Expect.equal (List.length positionedAtStartPublishedEvents) 0 "setting starting positions twice should not signal starting positions again"
-        ]
-        testList "move" [
-            testCase "move: cannot begin before starting positions are chosen" <| fun _ ->
-                let load, save = createMockStore ()
-                let publish, publishedEvents = createMockPublisher ()
-                let chargeForMovement, dispatchedCommands = createMockCommandDispatcher ()
-                let voidCharge, voidedCommands = createMockVoidCharge ()
-                let moveCommand = { MoveCommand.GameId = Guid.NewGuid (); Nation = "France"; Space = "Factory" }
-                let result = move load save publish chargeForMovement voidCharge moveCommand
-                Expect.isOk result "the move should be denied without breaking the game flow"
-                Expect.isNonEmpty publishedEvents "the rondel should signal why the move was denied"
-                Expect.contains publishedEvents (MoveToActionSpaceRejected { GameId = moveCommand.GameId; Nation = moveCommand.Nation; Space = moveCommand.Space }) "the rondel should signal that the move was denied"
-                Expect.isEmpty dispatchedCommands "no movement fee is due when the move is denied"
-
-            testPropertyWithConfig { FsCheckConfig.defaultConfig with maxTest = 15 } "move: nation’s first move may choose any rondel space (free)" <| fun (gameId: Guid) (nationIndex: int) (spaceIndex: int) ->
-            
-                let nations = [|"Austria"; "Britain"; "France"; "Germany"; "Italy"; "Russia"|]
-                let allSpaces = ["Investor"; "Factory"; "Import"; "ManeuverOne"; "ProductionOne"; "ManeuverTwo"; "ProductionTwo"; "Taxation"]
-
-                let nation = nations.[abs nationIndex % nations.Length]
-                let space = allSpaces.[abs spaceIndex % allSpaces.Length]
-
-                // Setup: initialize rondel
-                let load, save = createMockStore()
-                let publish, publishedEvents = createMockPublisher()
-                let chargeForMovement, dispatchedCommands = createMockCommandDispatcher()
-                let voidCharge, voidedCommands = createMockVoidCharge()
-
-                let initCommand = { GameId = gameId; Nations = nations }
-                setToStartingPositions load save publish initCommand |> ignore
-                publishedEvents.Clear()
-
-                // Execute: move one nation to target space
-                let moveCommand = { MoveCommand.GameId = gameId; Nation = nation; Space = space }
-                let result = move load save publish chargeForMovement voidCharge moveCommand
-
-                // Assert: move succeeds
-                Expect.isOk result "first move should allow choosing any rondel space"
-
-                // Assert: ActionDetermined event published with correct action
-                let expectedAction = spaceToAction space
-                Expect.contains publishedEvents (ActionDetermined { GameId = gameId; Nation = nation; Action = expectedAction }) (sprintf "the rondel space %s determines %s’s action: %s" space nation expectedAction)
-
-                // Assert: No charge commands dispatched (first move is free)
-                Expect.isEmpty dispatchedCommands "first move is free (no movement fee)"
-
-            testCase "move: rejects an unknown rondel space" <| fun _ ->
-                let load, save = createMockStore ()
-                let publish, publishedEvents = createMockPublisher ()
-                let chargeForMovement, dispatchedCommands = createMockCommandDispatcher ()
-                let voidCharge, voidedCommands = createMockVoidCharge ()
-
-                // Setup: initialize rondel with starting positions
-                let gameId = Guid.NewGuid ()
-                let initCommand = { GameId = gameId; Nations = [|"France"; "Germany"|] }
-                setToStartingPositions load save publish initCommand |> ignore
-                publishedEvents.Clear ()
-
-                // Execute: attempt to move to an invalid space
-                let moveCommand = { MoveCommand.GameId = gameId; Nation = "France"; Space = "InvalidSpace" }
-                let result = move load save publish chargeForMovement voidCharge moveCommand
-
-                // Assert: operation should fail
-                Expect.isError result "unknown rondel space is not allowed"
-
-                // Assert: No events published
-                Expect.isEmpty publishedEvents "an unknown space should not trigger any rondel signal"
-
-                // Assert: No charge commands dispatched
-                Expect.isEmpty dispatchedCommands "no movement fee is due for an invalid move"
-
-            testCase "move: requires a game id" <| fun _ ->
-                let load, save = createMockStore ()
-                let publish, publishedEvents = createMockPublisher ()
-                let chargeForMovement, dispatchedCommands = createMockCommandDispatcher ()
-                let voidCharge, voidedCommands = createMockVoidCharge ()
-
-                // Execute: attempt to move with empty game id
-                let moveCommand = { MoveCommand.GameId = Guid.Empty; Nation = "France"; Space = "Factory" }
-                let result = move load save publish chargeForMovement voidCharge moveCommand
-
-                // Assert: operation should fail
-                Expect.isError result "a move cannot be taken without a game id"
-
-                // Assert: No events published
-                Expect.isEmpty publishedEvents "without a game id, the rondel should not signal anything"
-
-                // Assert: No charge commands dispatched
-                Expect.isEmpty dispatchedCommands "no movement fee is due without a game id"
-
-            testPropertyWithConfig { FsCheckConfig.defaultConfig with maxTest = 15 } "move: rejects move to nation's current position repeatedly" <| fun (gameId: Guid) (nationIndex: int) (spaceIndex: int) ->
-
-                let nations = [|"Austria"; "Britain"; "France"; "Germany"; "Italy"; "Russia"|]
-                let allSpaces = ["Investor"; "Factory"; "Import"; "ManeuverOne"; "ProductionOne"; "ManeuverTwo"; "ProductionTwo"; "Taxation"]
-
-                let nation = nations.[abs nationIndex % nations.Length]
-                let space = allSpaces.[abs spaceIndex % allSpaces.Length]
-
-                // Setup: initialize rondel
-                let load, save = createMockStore()
-                let publish, publishedEvents = createMockPublisher()
-                let chargeForMovement, dispatchedCommands = createMockCommandDispatcher()
-                let voidCharge, voidedCommands = createMockVoidCharge()
-
-                let initCommand = { GameId = gameId; Nations = nations }
-                setToStartingPositions load save publish initCommand |> ignore
-                publishedEvents.Clear()
-
-                // Execute: move nation to target space (first move)
-                let moveCommand = { MoveCommand.GameId = gameId; Nation = nation; Space = space }
-                let firstMoveResult = move load save publish chargeForMovement voidCharge moveCommand
-
-                // Assert: first move succeeds
-                Expect.isOk firstMoveResult "first move should succeed"
-                let expectedAction = spaceToAction space
-                Expect.contains publishedEvents (ActionDetermined { GameId = gameId; Nation = nation; Action = expectedAction }) (sprintf "the rondel space %s determines %s's action: %s" space nation expectedAction)
-                publishedEvents.Clear()
-                dispatchedCommands.Clear()
-
-                // Execute: attempt to move to same position (first rejection)
-                let secondMoveResult = move load save publish chargeForMovement voidCharge moveCommand
-
-                // Assert: second move is rejected
-                Expect.isOk secondMoveResult "the move should be denied without breaking the game flow"
-                Expect.isNonEmpty publishedEvents "the rondel should signal why the move was denied"
-                Expect.contains publishedEvents (MoveToActionSpaceRejected { GameId = gameId; Nation = nation; Space = space }) (sprintf "%s's move to current position %s should be rejected" nation space)
-                Expect.isFalse (publishedEvents |> Seq.contains (ActionDetermined { GameId = gameId; Nation = nation; Action = expectedAction })) "no action should be determined when move to current position is rejected"
-                Expect.isEmpty dispatchedCommands "no movement fee is due when moving to current position"
-                publishedEvents.Clear()
-                dispatchedCommands.Clear()
-
-                // Execute: attempt to move to same position again (second rejection)
-                let thirdMoveResult = move load save publish chargeForMovement voidCharge moveCommand
-
-                // Assert: third move is also rejected
-                Expect.isOk thirdMoveResult "the move should be denied without breaking the game flow"
-                Expect.isNonEmpty publishedEvents "the rondel should signal why the move was denied"
-                Expect.contains publishedEvents (MoveToActionSpaceRejected { GameId = gameId; Nation = nation; Space = space }) (sprintf "%s's repeated move to current position %s should be rejected" nation space)
-                Expect.isFalse (publishedEvents |> Seq.contains (ActionDetermined { GameId = gameId; Nation = nation; Action = expectedAction })) "no action should be determined when move to current position is rejected repeatedly"
-                Expect.isEmpty dispatchedCommands "no movement fee is due when moving to current position repeatedly"
-
-            testPropertyWithConfig { FsCheckConfig.defaultConfig with maxTest = 15 } "move: multiple consecutive moves of 1-3 spaces are free" <| fun (gameId: Guid) (nationIndex: int) (startSpaceIndex: int) (distance1: int) (distance2: int) ->
-
-                let nations = [|"Austria"; "Britain"; "France"; "Germany"; "Italy"; "Russia"|]
-                let allSpaces = ["Investor"; "Import"; "ProductionOne"; "ManeuverOne"; "Taxation"; "Factory"; "ProductionTwo"; "ManeuverTwo"]
-
-                let nation = nations.[abs nationIndex % nations.Length]
-                let startIndex = abs startSpaceIndex % allSpaces.Length
-                let dist1 = abs distance1 % 3 + 1  // 1, 2, or 3
-                let dist2 = abs distance2 % 3 + 1  // 1, 2, or 3
-
-                // Setup: initialize rondel
-                let load, save = createMockStore()
-                let publish, publishedEvents = createMockPublisher()
-                let chargeForMovement, dispatchedCommands = createMockCommandDispatcher()
-                let voidCharge, voidedCommands = createMockVoidCharge()
-
-                let initCommand = { GameId = gameId; Nations = nations }
-                setToStartingPositions load save publish initCommand |> ignore
-                publishedEvents.Clear()
-
-                // First move: to starting position
-                let startSpace = allSpaces.[startIndex]
-                let moveCommand1 = { MoveCommand.GameId = gameId; Nation = nation; Space = startSpace }
-                let result1 = move load save publish chargeForMovement voidCharge moveCommand1
-
-                Expect.isOk result1 "first move should succeed"
-                let expectedAction1 = spaceToAction startSpace
-                Expect.contains publishedEvents (ActionDetermined { GameId = gameId; Nation = nation; Action = expectedAction1 }) (sprintf "%s's first move to %s should determine action %s" nation startSpace expectedAction1)
-                publishedEvents.Clear()
-                dispatchedCommands.Clear()
-
-                // Second move: 1-3 spaces forward
-                let secondIndex = (startIndex + dist1) % allSpaces.Length
-                let secondSpace = allSpaces.[secondIndex]
-                let moveCommand2 = { MoveCommand.GameId = gameId; Nation = nation; Space = secondSpace }
-                let result2 = move load save publish chargeForMovement voidCharge moveCommand2
-
-                Expect.isOk result2 (sprintf "second move (distance %d) should succeed" dist1)
-                let expectedAction2 = spaceToAction secondSpace
-                Expect.contains publishedEvents (ActionDetermined { GameId = gameId; Nation = nation; Action = expectedAction2 }) (sprintf "%s's move from %s to %s (distance %d) should determine action %s" nation startSpace secondSpace dist1 expectedAction2)
-                Expect.isEmpty dispatchedCommands (sprintf "move of %d spaces should be free" dist1)
-                publishedEvents.Clear()
-                dispatchedCommands.Clear()
-
-                // Third move: 1-3 spaces forward from second position
-                let thirdIndex = (secondIndex + dist2) % allSpaces.Length
-                let thirdSpace = allSpaces.[thirdIndex]
-                let moveCommand3 = { MoveCommand.GameId = gameId; Nation = nation; Space = thirdSpace }
-                let result3 = move load save publish chargeForMovement voidCharge moveCommand3
-
-                Expect.isOk result3 (sprintf "third move (distance %d) should succeed" dist2)
-                let expectedAction3 = spaceToAction thirdSpace
-                Expect.contains publishedEvents (ActionDetermined { GameId = gameId; Nation = nation; Action = expectedAction3 }) (sprintf "%s's move from %s to %s (distance %d) should determine action %s" nation secondSpace thirdSpace dist2 expectedAction3)
-                Expect.isEmpty dispatchedCommands (sprintf "move of %d spaces should be free" dist2)
-
-            testPropertyWithConfig { FsCheckConfig.defaultConfig with maxTest = 15 } "move: rejects moves of 7 spaces as exceeding maximum distance" <| fun (gameId: Guid) (nationIndex: int) (startSpaceIndex: int) ->
-
-                let nations = [|"Austria"; "Britain"; "France"; "Germany"; "Italy"; "Russia"|]
-                let allSpaces = ["Investor"; "Import"; "ProductionOne"; "ManeuverOne"; "Taxation"; "Factory"; "ProductionTwo"; "ManeuverTwo"]
-
-                let nation = nations.[abs nationIndex % nations.Length]
-                let startIndex = abs startSpaceIndex % allSpaces.Length
-
-                // Setup: initialize rondel
-                let load, save = createMockStore()
-                let publish, publishedEvents = createMockPublisher()
-                let chargeForMovement, dispatchedCommands = createMockCommandDispatcher()
-                let voidCharge, voidedCommands = createMockVoidCharge()
-
-                let initCommand = { GameId = gameId; Nations = nations }
-                setToStartingPositions load save publish initCommand |> ignore
-                publishedEvents.Clear()
-
-                // First move: establish starting position
-                let startSpace = allSpaces.[startIndex]
-                let moveCommand1 = { MoveCommand.GameId = gameId; Nation = nation; Space = startSpace }
-                let result1 = move load save publish chargeForMovement voidCharge moveCommand1
-
-                Expect.isOk result1 "first move should succeed"
-                let expectedAction1 = spaceToAction startSpace
-                Expect.contains publishedEvents (ActionDetermined { GameId = gameId; Nation = nation; Action = expectedAction1 }) (sprintf "%s's first move to %s should succeed" nation startSpace)
-                publishedEvents.Clear()
-                dispatchedCommands.Clear()
-
-                // Second move: attempt to move 7 spaces (invalid distance)
-                let targetIndex = (startIndex + 7) % allSpaces.Length
-                let targetSpace = allSpaces.[targetIndex]
-                let moveCommand2 = { MoveCommand.GameId = gameId; Nation = nation; Space = targetSpace }
-                let result2 = move load save publish chargeForMovement voidCharge moveCommand2
-
-                // Assert: move should be rejected (7 spaces exceeds maximum of 6)
-                Expect.isOk result2 "the move should be denied without breaking the game flow"
-                Expect.isNonEmpty publishedEvents "the rondel should signal why the move was denied"
-                Expect.contains publishedEvents (MoveToActionSpaceRejected { GameId = gameId; Nation = nation; Space = targetSpace }) (sprintf "%s's move from %s to %s (7 spaces) should be rejected as exceeding maximum distance" nation startSpace targetSpace)
-
-                // Assert: No action determined for invalid distance
-                let expectedAction2 = spaceToAction targetSpace
-                Expect.isFalse (publishedEvents |> Seq.contains (ActionDetermined { GameId = gameId; Nation = nation; Action = expectedAction2 })) "no action should be determined when move exceeds maximum distance"
-
-                // Assert: No charge commands dispatched
-                Expect.isEmpty dispatchedCommands "no movement fee is due for invalid moves"
-
-            testPropertyWithConfig { FsCheckConfig.defaultConfig with maxTest = 15 } "move: moves of 4-6 spaces require payment (2M per additional space beyond 3)" <| fun (gameId: Guid) (nationIndex: int) (startSpaceIndex: int) (distanceRaw: int) ->
-
-                let nations = [|"Austria"; "Britain"; "France"; "Germany"; "Italy"; "Russia"|]
-                let allSpaces = ["Investor"; "Import"; "ProductionOne"; "ManeuverOne"; "Taxation"; "Factory"; "ProductionTwo"; "ManeuverTwo"]
-
-                let nation = nations.[abs nationIndex % nations.Length]
-                let startIndex = abs startSpaceIndex % allSpaces.Length
-                let dist = abs distanceRaw % 3 + 4  // 4, 5, or 6
-
-                // Setup: initialize rondel
-                let load, save = createMockStore()
-                let publish, publishedEvents = createMockPublisher()
-                let chargeForMovement, dispatchedCommands = createMockCommandDispatcher()
-                let voidCharge, voidedCommands = createMockVoidCharge()
-
-                let initCommand = { GameId = gameId; Nations = nations }
-                setToStartingPositions load save publish initCommand |> ignore
-                publishedEvents.Clear()
-
-                // First move: establish starting position
-                let startSpace = allSpaces.[startIndex]
-                let moveCommand1 = { MoveCommand.GameId = gameId; Nation = nation; Space = startSpace }
-                let result1 = move load save publish chargeForMovement voidCharge moveCommand1
-
-                Expect.isOk result1 "first move should succeed"
-                publishedEvents.Clear()
-                dispatchedCommands.Clear()
-
-                // Second move: 4-6 spaces forward (requires payment)
-                let targetIndex = (startIndex + dist) % allSpaces.Length
-                let targetSpace = allSpaces.[targetIndex]
-                let moveCommand2 = { MoveCommand.GameId = gameId; Nation = nation; Space = targetSpace }
-                let result2 = move load save publish chargeForMovement voidCharge moveCommand2
-
-                // Assert: move command succeeds
-                Expect.isOk result2 (sprintf "move of %d spaces should be accepted (payment required)" dist)
-
-                // Assert: charge command dispatched with correct amount
-                Expect.hasLength dispatchedCommands 1 (sprintf "exactly one charge command should be dispatched for %d-space move" dist)
-                let chargeCmd = dispatchedCommands.[0]
-                Expect.equal chargeCmd.GameId gameId "charge command should have correct GameId"
-                Expect.equal chargeCmd.Nation nation "charge command should have correct Nation"
-
-                let expectedAmount = Imperium.Primitives.Amount.unsafe ((dist - 3) * 2)
-                Expect.equal chargeCmd.Amount expectedAmount (sprintf "charge for %d spaces should be %dM ((distance - 3) * 2)" dist ((dist - 3) * 2))
-
-                Expect.notEqual chargeCmd.BillingId Guid.Empty "charge command should have valid BillingId"
-
-                // Assert: NO ActionDetermined event (payment pending)
-                let actionDeterminedEvents = publishedEvents |> Seq.filter (function | ActionDetermined _ -> true | _ -> false) |> Seq.toList
-                Expect.isEmpty actionDeterminedEvents "no action should be determined until payment is confirmed"
-
-                // Assert: NO MoveToActionSpaceRejected event (move not rejected)
-                let rejectedEvents = publishedEvents |> Seq.filter (function | MoveToActionSpaceRejected _ -> true | _ -> false) |> Seq.toList
-                Expect.isEmpty rejectedEvents "move requiring payment should not be rejected"
-
-            testCase "move: superseding pending paid move with another paid move voids old charge and rejects old move" <| fun _ ->
-                // Setup
-                let load, save = createMockStore()
-                let publish, publishedEvents = createMockPublisher()
-                let chargeForMovement, dispatchedCommands = createMockCommandDispatcher()
-                let voidCharge, voidedCommands = createMockVoidCharge()
-
-                let gameId = Guid.NewGuid()
-                let nations = [|"France"|]
-
-                // Initialize rondel
-                setToStartingPositions load save publish { GameId = gameId; Nations = nations } |> ignore
-                publishedEvents.Clear()
-
-                // First move: Establish starting position (2 spaces, free)
-                move load save publish chargeForMovement voidCharge
-                    { GameId = gameId; Nation = "France"; Space = "ProductionOne" } |> ignore
-
-                Expect.contains publishedEvents (ActionDetermined { GameId = gameId; Nation = "France"; Action = "Production" })
-                    "first move should determine action"
-                publishedEvents.Clear()
-                dispatchedCommands.Clear()
-
-                // Second move: 4 spaces (pending payment) - ProductionOne to ProductionTwo
-                move load save publish chargeForMovement voidCharge
-                    { GameId = gameId; Nation = "France"; Space = "ProductionTwo" } |> ignore
-
-                Expect.hasLength dispatchedCommands 1 "first pending move should dispatch charge"
-                let firstBillingId = dispatchedCommands.[0].BillingId
-                Expect.equal dispatchedCommands.[0].Amount (Imperium.Primitives.Amount.unsafe 2) "charge for 4 spaces should be 2M"
-
-                let actionEvents1 = publishedEvents |> Seq.filter (function | ActionDetermined _ -> true | _ -> false) |> Seq.toList
-                Expect.isEmpty actionEvents1 "no action should be determined for pending move"
-
-                publishedEvents.Clear()
-                dispatchedCommands.Clear()
-
-                // Third move: 5 spaces (should supersede pending move) - ProductionOne to ManeuverTwo
-                move load save publish chargeForMovement voidCharge
-                    { GameId = gameId; Nation = "France"; Space = "ManeuverTwo" } |> ignore
-
-                // Assert: old charge voided
-                Expect.hasLength voidedCommands 1 "exactly one void command should be dispatched"
-                Expect.equal voidedCommands.[0].BillingId firstBillingId "should void the first billing"
-                Expect.equal voidedCommands.[0].GameId gameId "void command should have correct GameId"
-
-                // Assert: old move rejected
-                Expect.contains publishedEvents
-                    (MoveToActionSpaceRejected { GameId = gameId; Nation = "France"; Space = "ProductionTwo" })
-                    "first pending move should be rejected"
-
-                // Assert: new charge created
-                Expect.hasLength dispatchedCommands 1 "exactly one new charge should be dispatched"
-                let secondCharge = dispatchedCommands.[0]
-                Expect.equal secondCharge.Amount (Imperium.Primitives.Amount.unsafe 4) "charge for 5 spaces should be 4M"
-                Expect.notEqual secondCharge.BillingId firstBillingId "new charge should have different billing id"
-                Expect.equal secondCharge.GameId gameId "new charge should have correct GameId"
-                Expect.equal secondCharge.Nation "France" "new charge should have correct Nation"
-
-                // Assert: no action determined (new move still pending payment)
-                let actionEvents2 = publishedEvents |> Seq.filter (function | ActionDetermined _ -> true | _ -> false) |> Seq.toList
-                Expect.isEmpty actionEvents2 "no action should be determined for new pending move"
-
-            testCase "move: superseding pending paid move with free move voids charge and completes immediately" <| fun _ ->
-                // Setup
-                let load, save = createMockStore()
-                let publish, publishedEvents = createMockPublisher()
-                let chargeForMovement, dispatchedCommands = createMockCommandDispatcher()
-                let voidCharge, voidedCommands = createMockVoidCharge()
-
-                let gameId = Guid.NewGuid()
-                let nations = [|"Germany"|]
-
-                // Initialize rondel
-                setToStartingPositions load save publish { GameId = gameId; Nations = nations } |> ignore
-                publishedEvents.Clear()
-
-                // First move: Establish starting position (3 spaces, free)
-                move load save publish chargeForMovement voidCharge
-                    { GameId = gameId; Nation = "Germany"; Space = "ManeuverOne" } |> ignore
-
-                Expect.contains publishedEvents (ActionDetermined { GameId = gameId; Nation = "Germany"; Action = "Maneuver" })
-                    "first move should determine action"
-                publishedEvents.Clear()
-                dispatchedCommands.Clear()
-
-                // Second move: 5 spaces (pending payment) - ManeuverOne to Investor
-                move load save publish chargeForMovement voidCharge
-                    { GameId = gameId; Nation = "Germany"; Space = "Investor" } |> ignore
-
-                Expect.hasLength dispatchedCommands 1 "first pending move should dispatch charge"
-                let firstBillingId = dispatchedCommands.[0].BillingId
-                Expect.equal dispatchedCommands.[0].Amount (Imperium.Primitives.Amount.unsafe 4) "charge for 5 spaces should be 4M"
-
-                let actionEvents1 = publishedEvents |> Seq.filter (function | ActionDetermined _ -> true | _ -> false) |> Seq.toList
-                Expect.isEmpty actionEvents1 "no action should be determined for pending move"
-
-                publishedEvents.Clear()
-                dispatchedCommands.Clear()
-
-                // Third move: 2 spaces (free, should supersede and complete immediately) - ManeuverOne to Factory
-                move load save publish chargeForMovement voidCharge
-                    { GameId = gameId; Nation = "Germany"; Space = "Factory" } |> ignore
-
-                // Assert: old charge voided
-                Expect.hasLength voidedCommands 1 "exactly one void command should be dispatched"
-                Expect.equal voidedCommands.[0].BillingId firstBillingId "should void the first billing"
-                Expect.equal voidedCommands.[0].GameId gameId "void command should have correct GameId"
-
-                // Assert: old move rejected
-                Expect.contains publishedEvents
-                    (MoveToActionSpaceRejected { GameId = gameId; Nation = "Germany"; Space = "Investor" })
-                    "first pending move should be rejected"
-
-                // Assert: no new charge (free move)
-                Expect.isEmpty dispatchedCommands "free move should not dispatch charge command"
-
-                // Assert: action determined for new move (free move completes immediately)
-                Expect.contains publishedEvents (ActionDetermined { GameId = gameId; Nation = "Germany"; Action = "Factory" })
-                    "free move should determine action immediately despite superseding"
-        ]
-        testList "onInvoicePaid" [
-            testCase "onInvoicePaid: completes pending movement and publishes ActionDetermined event" <| fun _ ->
-                // Setup: create mocks
-                let load, save = createMockStore()
-                let publish, publishedEvents = createMockPublisher()
-                let chargeForMovement, dispatchedCommands = createMockCommandDispatcher()
-                let voidCharge, voidedCommands = createMockVoidCharge()
-
-                let gameId = Guid.NewGuid()
-                let nations = [|"Austria"|]
-
-                // Setup: initialize rondel
-                setToStartingPositions load save publish { GameId = gameId; Nations = nations } |> ignore
-                publishedEvents.Clear()
-
-                // Setup: establish starting position with first move (free to any space)
-                move load save publish chargeForMovement voidCharge
-                    { GameId = gameId; Nation = "Austria"; Space = "ManeuverOne" } |> ignore
-
-                Expect.contains publishedEvents (ActionDetermined { GameId = gameId; Nation = "Austria"; Action = "Maneuver" })
-                    "first move should complete immediately"
-                publishedEvents.Clear()
-                dispatchedCommands.Clear()
-
-                // Setup: initiate paid move (5 spaces: ManeuverOne to Investor) - creates pending movement
-                move load save publish chargeForMovement voidCharge
-                    { GameId = gameId; Nation = "Austria"; Space = "Investor" } |> ignore
-
-                Expect.hasLength dispatchedCommands 1 "paid move should dispatch charge command"
-                let billingId = dispatchedCommands.[0].BillingId
-                Expect.equal dispatchedCommands.[0].Amount (Imperium.Primitives.Amount.unsafe 4)
-                    "charge for 5 spaces should be 4M"
-
-                let actionEvents = publishedEvents |> Seq.filter (function | ActionDetermined _ -> true | _ -> false) |> Seq.toList
-                Expect.isEmpty actionEvents "no action should be determined until payment confirmed"
-
-                publishedEvents.Clear()
-                dispatchedCommands.Clear()
-
-                // Execute: process payment confirmation
-                let paymentEvent : Imperium.Contract.Accounting.RondelInvoicePaid = { GameId = gameId; BillingId = billingId }
-                let result = onInvoicedPaid load save publish paymentEvent
-
-                // Assert: operation succeeds
-                Expect.isOk result "payment confirmation should succeed"
-
-                // Assert: ActionDetermined event published for target space
-                Expect.contains publishedEvents (ActionDetermined { GameId = gameId; Nation = "Austria"; Action = "Investor" })
-                    "ActionDetermined event should be published after payment confirmation"
-
-                // Assert: only one event published
-                Expect.hasLength publishedEvents 1 "only ActionDetermined event should be published"
-
-                // Assert: no additional charges or voids
-                Expect.isEmpty dispatchedCommands "no new charges after payment confirmation"
-                Expect.isEmpty voidedCommands "no voids after successful payment"
-
-                // Assert: verify state updated - pending movement cleared, position updated
-                // Subsequent move from Investor (new position) should succeed
-                publishedEvents.Clear()
-
-                move load save publish chargeForMovement voidCharge
-                    { GameId = gameId; Nation = "Austria"; Space = "Import" } |> ignore
-
-                Expect.contains publishedEvents (ActionDetermined { GameId = gameId; Nation = "Austria"; Action = "Import" })
-                    "subsequent move from Investor to Import (1 space) should succeed, confirming position was updated"
-        ]
-    ]
+let tests =
+    testList
+        "Rondel"
+        [
+          // Tests for public Rondel API
+          testList
+              "starting positions"
+              [ testCase "starting positions: requires a game id"
+                <| fun _ ->
+                    let load, save = createMockStore ()
+                    let publish, _ = createMockPublisher ()
+
+                    let command =
+                        { GameId = Guid.Empty
+                          Nations = [| "France" |] }
+
+                    let result = setToStartingPositions load save publish command
+                    Expect.isError result "starting positions cannot be chosen without a game id"
+                testCase "starting positions: requires at least one nation"
+                <| fun _ ->
+                    let load, save = createMockStore ()
+                    let publish, _ = createMockPublisher ()
+
+                    let command =
+                        { GameId = Guid.NewGuid()
+                          Nations = [||] }
+
+                    let result = setToStartingPositions load save publish command
+                    Expect.isError result "starting positions require at least one nation"
+                testCase "starting positions: ignores duplicate nations"
+                <| fun _ ->
+                    let load, save = createMockStore ()
+                    let publish, publishedEvents = createMockPublisher ()
+
+                    let command =
+                        { GameId = Guid.NewGuid()
+                          Nations = [| "France"; "France" |] }
+
+                    let result = setToStartingPositions load save publish command
+                    Expect.isOk result "starting positions accept the roster (duplicates ignored)"
+                    Expect.isNonEmpty publishedEvents "the rondel should signal that starting positions are set"
+
+                    Expect.contains
+                        publishedEvents
+                        (PositionedAtStart { GameId = command.GameId })
+                        "the rondel should signal that starting positions are set"
+                testCase "starting positions: signals setup for the roster"
+                <| fun _ ->
+                    let load, save = createMockStore ()
+                    let publish, publishedEvents = createMockPublisher ()
+
+                    let command =
+                        { GameId = Guid.NewGuid()
+                          Nations = [| "France"; "Germany" |] }
+
+                    let result = setToStartingPositions load save publish command
+                    Expect.isOk result "starting positions should be accepted"
+                    Expect.isNonEmpty publishedEvents "the rondel should signal that starting positions are set"
+
+                    Expect.contains
+                        publishedEvents
+                        (PositionedAtStart { GameId = command.GameId })
+                        "the rondel should signal that starting positions are set"
+                testCase "starting positions: setting twice does not signal again"
+                <| fun _ ->
+                    let load, save = createMockStore ()
+                    let publish, publishedEvents = createMockPublisher ()
+
+                    let command =
+                        { GameId = Guid.NewGuid()
+                          Nations = [| "France"; "Germany" |] }
+                    // First call to set positions
+                    let _ = setToStartingPositions load save publish command
+                    publishedEvents.Clear()
+                    // Second call to set positions again
+                    let result = setToStartingPositions load save publish command
+                    Expect.isOk result "setting starting positions twice should not fail"
+
+                    let positionedAtStartPublishedEvents =
+                        publishedEvents
+                        |> Seq.filter (function
+                            | PositionedAtStart _ -> true
+                            | _ -> false)
+                        |> Seq.toList
+
+                    Expect.equal
+                        (List.length positionedAtStartPublishedEvents)
+                        0
+                        "setting starting positions twice should not signal starting positions again" ]
+          testList
+              "move"
+              [ testCase "move: cannot begin before starting positions are chosen"
+                <| fun _ ->
+                    let load, save = createMockStore ()
+                    let publish, publishedEvents = createMockPublisher ()
+                    let chargeForMovement, dispatchedCommands = createMockCommandDispatcher ()
+                    let voidCharge, voidedCommands = createMockVoidCharge ()
+
+                    let moveCommand =
+                        { MoveCommand.GameId = Guid.NewGuid()
+                          Nation = "France"
+                          Space = "Factory" }
+
+                    let result = move load save publish chargeForMovement voidCharge moveCommand
+                    Expect.isOk result "the move should be denied without breaking the game flow"
+                    Expect.isNonEmpty publishedEvents "the rondel should signal why the move was denied"
+
+                    Expect.contains
+                        publishedEvents
+                        (MoveToActionSpaceRejected
+                            { GameId = moveCommand.GameId
+                              Nation = moveCommand.Nation
+                              Space = moveCommand.Space })
+                        "the rondel should signal that the move was denied"
+
+                    Expect.isEmpty dispatchedCommands "no movement fee is due when the move is denied"
+
+                testPropertyWithConfig
+                    { FsCheckConfig.defaultConfig with
+                        maxTest = 15 }
+                    "move: nation’s first move may choose any rondel space (free)"
+                <| fun (gameId: Guid) (nationIndex: int) (spaceIndex: int) ->
+
+                    let nations = [| "Austria"; "Britain"; "France"; "Germany"; "Italy"; "Russia" |]
+
+                    let allSpaces =
+                        [ "Investor"
+                          "Factory"
+                          "Import"
+                          "ManeuverOne"
+                          "ProductionOne"
+                          "ManeuverTwo"
+                          "ProductionTwo"
+                          "Taxation" ]
+
+                    let nation = nations.[abs nationIndex % nations.Length]
+                    let space = allSpaces.[abs spaceIndex % allSpaces.Length]
+
+                    // Setup: initialize rondel
+                    let load, save = createMockStore ()
+                    let publish, publishedEvents = createMockPublisher ()
+                    let chargeForMovement, dispatchedCommands = createMockCommandDispatcher ()
+                    let voidCharge, voidedCommands = createMockVoidCharge ()
+
+                    let initCommand = { GameId = gameId; Nations = nations }
+                    setToStartingPositions load save publish initCommand |> ignore
+                    publishedEvents.Clear()
+
+                    // Execute: move one nation to target space
+                    let moveCommand =
+                        { MoveCommand.GameId = gameId
+                          Nation = nation
+                          Space = space }
+
+                    let result = move load save publish chargeForMovement voidCharge moveCommand
+
+                    // Assert: move succeeds
+                    Expect.isOk result "first move should allow choosing any rondel space"
+
+                    // Assert: ActionDetermined event published with correct action
+                    let expectedAction = spaceToAction space
+
+                    Expect.contains
+                        publishedEvents
+                        (ActionDetermined
+                            { GameId = gameId
+                              Nation = nation
+                              Action = expectedAction })
+                        (sprintf "the rondel space %s determines %s’s action: %s" space nation expectedAction)
+
+                    // Assert: No charge commands dispatched (first move is free)
+                    Expect.isEmpty dispatchedCommands "first move is free (no movement fee)"
+
+                testCase "move: rejects an unknown rondel space"
+                <| fun _ ->
+                    let load, save = createMockStore ()
+                    let publish, publishedEvents = createMockPublisher ()
+                    let chargeForMovement, dispatchedCommands = createMockCommandDispatcher ()
+                    let voidCharge, voidedCommands = createMockVoidCharge ()
+
+                    // Setup: initialize rondel with starting positions
+                    let gameId = Guid.NewGuid()
+
+                    let initCommand =
+                        { GameId = gameId
+                          Nations = [| "France"; "Germany" |] }
+
+                    setToStartingPositions load save publish initCommand |> ignore
+                    publishedEvents.Clear()
+
+                    // Execute: attempt to move to an invalid space
+                    let moveCommand =
+                        { MoveCommand.GameId = gameId
+                          Nation = "France"
+                          Space = "InvalidSpace" }
+
+                    let result = move load save publish chargeForMovement voidCharge moveCommand
+
+                    // Assert: operation should fail
+                    Expect.isError result "unknown rondel space is not allowed"
+
+                    // Assert: No events published
+                    Expect.isEmpty publishedEvents "an unknown space should not trigger any rondel signal"
+
+                    // Assert: No charge commands dispatched
+                    Expect.isEmpty dispatchedCommands "no movement fee is due for an invalid move"
+
+                testCase "move: requires a game id"
+                <| fun _ ->
+                    let load, save = createMockStore ()
+                    let publish, publishedEvents = createMockPublisher ()
+                    let chargeForMovement, dispatchedCommands = createMockCommandDispatcher ()
+                    let voidCharge, voidedCommands = createMockVoidCharge ()
+
+                    // Execute: attempt to move with empty game id
+                    let moveCommand =
+                        { MoveCommand.GameId = Guid.Empty
+                          Nation = "France"
+                          Space = "Factory" }
+
+                    let result = move load save publish chargeForMovement voidCharge moveCommand
+
+                    // Assert: operation should fail
+                    Expect.isError result "a move cannot be taken without a game id"
+
+                    // Assert: No events published
+                    Expect.isEmpty publishedEvents "without a game id, the rondel should not signal anything"
+
+                    // Assert: No charge commands dispatched
+                    Expect.isEmpty dispatchedCommands "no movement fee is due without a game id"
+
+                testPropertyWithConfig
+                    { FsCheckConfig.defaultConfig with
+                        maxTest = 15 }
+                    "move: rejects move to nation's current position repeatedly"
+                <| fun (gameId: Guid) (nationIndex: int) (spaceIndex: int) ->
+
+                    let nations = [| "Austria"; "Britain"; "France"; "Germany"; "Italy"; "Russia" |]
+
+                    let allSpaces =
+                        [ "Investor"
+                          "Factory"
+                          "Import"
+                          "ManeuverOne"
+                          "ProductionOne"
+                          "ManeuverTwo"
+                          "ProductionTwo"
+                          "Taxation" ]
+
+                    let nation = nations.[abs nationIndex % nations.Length]
+                    let space = allSpaces.[abs spaceIndex % allSpaces.Length]
+
+                    // Setup: initialize rondel
+                    let load, save = createMockStore ()
+                    let publish, publishedEvents = createMockPublisher ()
+                    let chargeForMovement, dispatchedCommands = createMockCommandDispatcher ()
+                    let voidCharge, voidedCommands = createMockVoidCharge ()
+
+                    let initCommand = { GameId = gameId; Nations = nations }
+                    setToStartingPositions load save publish initCommand |> ignore
+                    publishedEvents.Clear()
+
+                    // Execute: move nation to target space (first move)
+                    let moveCommand =
+                        { MoveCommand.GameId = gameId
+                          Nation = nation
+                          Space = space }
+
+                    let firstMoveResult =
+                        move load save publish chargeForMovement voidCharge moveCommand
+
+                    // Assert: first move succeeds
+                    Expect.isOk firstMoveResult "first move should succeed"
+                    let expectedAction = spaceToAction space
+
+                    Expect.contains
+                        publishedEvents
+                        (ActionDetermined
+                            { GameId = gameId
+                              Nation = nation
+                              Action = expectedAction })
+                        (sprintf "the rondel space %s determines %s's action: %s" space nation expectedAction)
+
+                    publishedEvents.Clear()
+                    dispatchedCommands.Clear()
+
+                    // Execute: attempt to move to same position (first rejection)
+                    let secondMoveResult =
+                        move load save publish chargeForMovement voidCharge moveCommand
+
+                    // Assert: second move is rejected
+                    Expect.isOk secondMoveResult "the move should be denied without breaking the game flow"
+                    Expect.isNonEmpty publishedEvents "the rondel should signal why the move was denied"
+
+                    Expect.contains
+                        publishedEvents
+                        (MoveToActionSpaceRejected
+                            { GameId = gameId
+                              Nation = nation
+                              Space = space })
+                        (sprintf "%s's move to current position %s should be rejected" nation space)
+
+                    Expect.isFalse
+                        (publishedEvents
+                         |> Seq.contains (
+                             ActionDetermined
+                                 { GameId = gameId
+                                   Nation = nation
+                                   Action = expectedAction }
+                         ))
+                        "no action should be determined when move to current position is rejected"
+
+                    Expect.isEmpty dispatchedCommands "no movement fee is due when moving to current position"
+                    publishedEvents.Clear()
+                    dispatchedCommands.Clear()
+
+                    // Execute: attempt to move to same position again (second rejection)
+                    let thirdMoveResult =
+                        move load save publish chargeForMovement voidCharge moveCommand
+
+                    // Assert: third move is also rejected
+                    Expect.isOk thirdMoveResult "the move should be denied without breaking the game flow"
+                    Expect.isNonEmpty publishedEvents "the rondel should signal why the move was denied"
+
+                    Expect.contains
+                        publishedEvents
+                        (MoveToActionSpaceRejected
+                            { GameId = gameId
+                              Nation = nation
+                              Space = space })
+                        (sprintf "%s's repeated move to current position %s should be rejected" nation space)
+
+                    Expect.isFalse
+                        (publishedEvents
+                         |> Seq.contains (
+                             ActionDetermined
+                                 { GameId = gameId
+                                   Nation = nation
+                                   Action = expectedAction }
+                         ))
+                        "no action should be determined when move to current position is rejected repeatedly"
+
+                    Expect.isEmpty
+                        dispatchedCommands
+                        "no movement fee is due when moving to current position repeatedly"
+
+                testPropertyWithConfig
+                    { FsCheckConfig.defaultConfig with
+                        maxTest = 15 }
+                    "move: multiple consecutive moves of 1-3 spaces are free"
+                <| fun (gameId: Guid) (nationIndex: int) (startSpaceIndex: int) (distance1: int) (distance2: int) ->
+
+                    let nations = [| "Austria"; "Britain"; "France"; "Germany"; "Italy"; "Russia" |]
+
+                    let allSpaces =
+                        [ "Investor"
+                          "Import"
+                          "ProductionOne"
+                          "ManeuverOne"
+                          "Taxation"
+                          "Factory"
+                          "ProductionTwo"
+                          "ManeuverTwo" ]
+
+                    let nation = nations.[abs nationIndex % nations.Length]
+                    let startIndex = abs startSpaceIndex % allSpaces.Length
+                    let dist1 = abs distance1 % 3 + 1 // 1, 2, or 3
+                    let dist2 = abs distance2 % 3 + 1 // 1, 2, or 3
+
+                    // Setup: initialize rondel
+                    let load, save = createMockStore ()
+                    let publish, publishedEvents = createMockPublisher ()
+                    let chargeForMovement, dispatchedCommands = createMockCommandDispatcher ()
+                    let voidCharge, voidedCommands = createMockVoidCharge ()
+
+                    let initCommand = { GameId = gameId; Nations = nations }
+                    setToStartingPositions load save publish initCommand |> ignore
+                    publishedEvents.Clear()
+
+                    // First move: to starting position
+                    let startSpace = allSpaces.[startIndex]
+
+                    let moveCommand1 =
+                        { MoveCommand.GameId = gameId
+                          Nation = nation
+                          Space = startSpace }
+
+                    let result1 = move load save publish chargeForMovement voidCharge moveCommand1
+
+                    Expect.isOk result1 "first move should succeed"
+                    let expectedAction1 = spaceToAction startSpace
+
+                    Expect.contains
+                        publishedEvents
+                        (ActionDetermined
+                            { GameId = gameId
+                              Nation = nation
+                              Action = expectedAction1 })
+                        (sprintf "%s's first move to %s should determine action %s" nation startSpace expectedAction1)
+
+                    publishedEvents.Clear()
+                    dispatchedCommands.Clear()
+
+                    // Second move: 1-3 spaces forward
+                    let secondIndex = (startIndex + dist1) % allSpaces.Length
+                    let secondSpace = allSpaces.[secondIndex]
+
+                    let moveCommand2 =
+                        { MoveCommand.GameId = gameId
+                          Nation = nation
+                          Space = secondSpace }
+
+                    let result2 = move load save publish chargeForMovement voidCharge moveCommand2
+
+                    Expect.isOk result2 (sprintf "second move (distance %d) should succeed" dist1)
+                    let expectedAction2 = spaceToAction secondSpace
+
+                    Expect.contains
+                        publishedEvents
+                        (ActionDetermined
+                            { GameId = gameId
+                              Nation = nation
+                              Action = expectedAction2 })
+                        (sprintf
+                            "%s's move from %s to %s (distance %d) should determine action %s"
+                            nation
+                            startSpace
+                            secondSpace
+                            dist1
+                            expectedAction2)
+
+                    Expect.isEmpty dispatchedCommands (sprintf "move of %d spaces should be free" dist1)
+                    publishedEvents.Clear()
+                    dispatchedCommands.Clear()
+
+                    // Third move: 1-3 spaces forward from second position
+                    let thirdIndex = (secondIndex + dist2) % allSpaces.Length
+                    let thirdSpace = allSpaces.[thirdIndex]
+
+                    let moveCommand3 =
+                        { MoveCommand.GameId = gameId
+                          Nation = nation
+                          Space = thirdSpace }
+
+                    let result3 = move load save publish chargeForMovement voidCharge moveCommand3
+
+                    Expect.isOk result3 (sprintf "third move (distance %d) should succeed" dist2)
+                    let expectedAction3 = spaceToAction thirdSpace
+
+                    Expect.contains
+                        publishedEvents
+                        (ActionDetermined
+                            { GameId = gameId
+                              Nation = nation
+                              Action = expectedAction3 })
+                        (sprintf
+                            "%s's move from %s to %s (distance %d) should determine action %s"
+                            nation
+                            secondSpace
+                            thirdSpace
+                            dist2
+                            expectedAction3)
+
+                    Expect.isEmpty dispatchedCommands (sprintf "move of %d spaces should be free" dist2)
+
+                testPropertyWithConfig
+                    { FsCheckConfig.defaultConfig with
+                        maxTest = 15 }
+                    "move: rejects moves of 7 spaces as exceeding maximum distance"
+                <| fun (gameId: Guid) (nationIndex: int) (startSpaceIndex: int) ->
+
+                    let nations = [| "Austria"; "Britain"; "France"; "Germany"; "Italy"; "Russia" |]
+
+                    let allSpaces =
+                        [ "Investor"
+                          "Import"
+                          "ProductionOne"
+                          "ManeuverOne"
+                          "Taxation"
+                          "Factory"
+                          "ProductionTwo"
+                          "ManeuverTwo" ]
+
+                    let nation = nations.[abs nationIndex % nations.Length]
+                    let startIndex = abs startSpaceIndex % allSpaces.Length
+
+                    // Setup: initialize rondel
+                    let load, save = createMockStore ()
+                    let publish, publishedEvents = createMockPublisher ()
+                    let chargeForMovement, dispatchedCommands = createMockCommandDispatcher ()
+                    let voidCharge, voidedCommands = createMockVoidCharge ()
+
+                    let initCommand = { GameId = gameId; Nations = nations }
+                    setToStartingPositions load save publish initCommand |> ignore
+                    publishedEvents.Clear()
+
+                    // First move: establish starting position
+                    let startSpace = allSpaces.[startIndex]
+
+                    let moveCommand1 =
+                        { MoveCommand.GameId = gameId
+                          Nation = nation
+                          Space = startSpace }
+
+                    let result1 = move load save publish chargeForMovement voidCharge moveCommand1
+
+                    Expect.isOk result1 "first move should succeed"
+                    let expectedAction1 = spaceToAction startSpace
+
+                    Expect.contains
+                        publishedEvents
+                        (ActionDetermined
+                            { GameId = gameId
+                              Nation = nation
+                              Action = expectedAction1 })
+                        (sprintf "%s's first move to %s should succeed" nation startSpace)
+
+                    publishedEvents.Clear()
+                    dispatchedCommands.Clear()
+
+                    // Second move: attempt to move 7 spaces (invalid distance)
+                    let targetIndex = (startIndex + 7) % allSpaces.Length
+                    let targetSpace = allSpaces.[targetIndex]
+
+                    let moveCommand2 =
+                        { MoveCommand.GameId = gameId
+                          Nation = nation
+                          Space = targetSpace }
+
+                    let result2 = move load save publish chargeForMovement voidCharge moveCommand2
+
+                    // Assert: move should be rejected (7 spaces exceeds maximum of 6)
+                    Expect.isOk result2 "the move should be denied without breaking the game flow"
+                    Expect.isNonEmpty publishedEvents "the rondel should signal why the move was denied"
+
+                    Expect.contains
+                        publishedEvents
+                        (MoveToActionSpaceRejected
+                            { GameId = gameId
+                              Nation = nation
+                              Space = targetSpace })
+                        (sprintf
+                            "%s's move from %s to %s (7 spaces) should be rejected as exceeding maximum distance"
+                            nation
+                            startSpace
+                            targetSpace)
+
+                    // Assert: No action determined for invalid distance
+                    let expectedAction2 = spaceToAction targetSpace
+
+                    Expect.isFalse
+                        (publishedEvents
+                         |> Seq.contains (
+                             ActionDetermined
+                                 { GameId = gameId
+                                   Nation = nation
+                                   Action = expectedAction2 }
+                         ))
+                        "no action should be determined when move exceeds maximum distance"
+
+                    // Assert: No charge commands dispatched
+                    Expect.isEmpty dispatchedCommands "no movement fee is due for invalid moves"
+
+                testPropertyWithConfig
+                    { FsCheckConfig.defaultConfig with
+                        maxTest = 15 }
+                    "move: moves of 4-6 spaces require payment (2M per additional space beyond 3)"
+                <| fun (gameId: Guid) (nationIndex: int) (startSpaceIndex: int) (distanceRaw: int) ->
+
+                    let nations = [| "Austria"; "Britain"; "France"; "Germany"; "Italy"; "Russia" |]
+
+                    let allSpaces =
+                        [ "Investor"
+                          "Import"
+                          "ProductionOne"
+                          "ManeuverOne"
+                          "Taxation"
+                          "Factory"
+                          "ProductionTwo"
+                          "ManeuverTwo" ]
+
+                    let nation = nations.[abs nationIndex % nations.Length]
+                    let startIndex = abs startSpaceIndex % allSpaces.Length
+                    let dist = abs distanceRaw % 3 + 4 // 4, 5, or 6
+
+                    // Setup: initialize rondel
+                    let load, save = createMockStore ()
+                    let publish, publishedEvents = createMockPublisher ()
+                    let chargeForMovement, dispatchedCommands = createMockCommandDispatcher ()
+                    let voidCharge, voidedCommands = createMockVoidCharge ()
+
+                    let initCommand = { GameId = gameId; Nations = nations }
+                    setToStartingPositions load save publish initCommand |> ignore
+                    publishedEvents.Clear()
+
+                    // First move: establish starting position
+                    let startSpace = allSpaces.[startIndex]
+
+                    let moveCommand1 =
+                        { MoveCommand.GameId = gameId
+                          Nation = nation
+                          Space = startSpace }
+
+                    let result1 = move load save publish chargeForMovement voidCharge moveCommand1
+
+                    Expect.isOk result1 "first move should succeed"
+                    publishedEvents.Clear()
+                    dispatchedCommands.Clear()
+
+                    // Second move: 4-6 spaces forward (requires payment)
+                    let targetIndex = (startIndex + dist) % allSpaces.Length
+                    let targetSpace = allSpaces.[targetIndex]
+
+                    let moveCommand2 =
+                        { MoveCommand.GameId = gameId
+                          Nation = nation
+                          Space = targetSpace }
+
+                    let result2 = move load save publish chargeForMovement voidCharge moveCommand2
+
+                    // Assert: move command succeeds
+                    Expect.isOk result2 (sprintf "move of %d spaces should be accepted (payment required)" dist)
+
+                    // Assert: charge command dispatched with correct amount
+                    Expect.hasLength
+                        dispatchedCommands
+                        1
+                        (sprintf "exactly one charge command should be dispatched for %d-space move" dist)
+
+                    let chargeCmd = dispatchedCommands.[0]
+                    Expect.equal chargeCmd.GameId gameId "charge command should have correct GameId"
+                    Expect.equal chargeCmd.Nation nation "charge command should have correct Nation"
+
+                    let expectedAmount = Imperium.Primitives.Amount.unsafe ((dist - 3) * 2)
+
+                    Expect.equal
+                        chargeCmd.Amount
+                        expectedAmount
+                        (sprintf "charge for %d spaces should be %dM ((distance - 3) * 2)" dist ((dist - 3) * 2))
+
+                    Expect.notEqual chargeCmd.BillingId Guid.Empty "charge command should have valid BillingId"
+
+                    // Assert: NO ActionDetermined event (payment pending)
+                    let actionDeterminedEvents =
+                        publishedEvents
+                        |> Seq.filter (function
+                            | ActionDetermined _ -> true
+                            | _ -> false)
+                        |> Seq.toList
+
+                    Expect.isEmpty actionDeterminedEvents "no action should be determined until payment is confirmed"
+
+                    // Assert: NO MoveToActionSpaceRejected event (move not rejected)
+                    let rejectedEvents =
+                        publishedEvents
+                        |> Seq.filter (function
+                            | MoveToActionSpaceRejected _ -> true
+                            | _ -> false)
+                        |> Seq.toList
+
+                    Expect.isEmpty rejectedEvents "move requiring payment should not be rejected"
+
+                testCase
+                    "move: superseding pending paid move with another paid move voids old charge and rejects old move"
+                <| fun _ ->
+                    // Setup
+                    let load, save = createMockStore ()
+                    let publish, publishedEvents = createMockPublisher ()
+                    let chargeForMovement, dispatchedCommands = createMockCommandDispatcher ()
+                    let voidCharge, voidedCommands = createMockVoidCharge ()
+
+                    let gameId = Guid.NewGuid()
+                    let nations = [| "France" |]
+
+                    // Initialize rondel
+                    setToStartingPositions load save publish { GameId = gameId; Nations = nations }
+                    |> ignore
+
+                    publishedEvents.Clear()
+
+                    // First move: Establish starting position (2 spaces, free)
+                    move
+                        load
+                        save
+                        publish
+                        chargeForMovement
+                        voidCharge
+                        { GameId = gameId
+                          Nation = "France"
+                          Space = "ProductionOne" }
+                    |> ignore
+
+                    Expect.contains
+                        publishedEvents
+                        (ActionDetermined
+                            { GameId = gameId
+                              Nation = "France"
+                              Action = "Production" })
+                        "first move should determine action"
+
+                    publishedEvents.Clear()
+                    dispatchedCommands.Clear()
+
+                    // Second move: 4 spaces (pending payment) - ProductionOne to ProductionTwo
+                    move
+                        load
+                        save
+                        publish
+                        chargeForMovement
+                        voidCharge
+                        { GameId = gameId
+                          Nation = "France"
+                          Space = "ProductionTwo" }
+                    |> ignore
+
+                    Expect.hasLength dispatchedCommands 1 "first pending move should dispatch charge"
+                    let firstBillingId = dispatchedCommands.[0].BillingId
+
+                    Expect.equal
+                        dispatchedCommands.[0].Amount
+                        (Imperium.Primitives.Amount.unsafe 2)
+                        "charge for 4 spaces should be 2M"
+
+                    let actionEvents1 =
+                        publishedEvents
+                        |> Seq.filter (function
+                            | ActionDetermined _ -> true
+                            | _ -> false)
+                        |> Seq.toList
+
+                    Expect.isEmpty actionEvents1 "no action should be determined for pending move"
+
+                    publishedEvents.Clear()
+                    dispatchedCommands.Clear()
+
+                    // Third move: 5 spaces (should supersede pending move) - ProductionOne to ManeuverTwo
+                    move
+                        load
+                        save
+                        publish
+                        chargeForMovement
+                        voidCharge
+                        { GameId = gameId
+                          Nation = "France"
+                          Space = "ManeuverTwo" }
+                    |> ignore
+
+                    // Assert: old charge voided
+                    Expect.hasLength voidedCommands 1 "exactly one void command should be dispatched"
+                    Expect.equal voidedCommands.[0].BillingId firstBillingId "should void the first billing"
+                    Expect.equal voidedCommands.[0].GameId gameId "void command should have correct GameId"
+
+                    // Assert: old move rejected
+                    Expect.contains
+                        publishedEvents
+                        (MoveToActionSpaceRejected
+                            { GameId = gameId
+                              Nation = "France"
+                              Space = "ProductionTwo" })
+                        "first pending move should be rejected"
+
+                    // Assert: new charge created
+                    Expect.hasLength dispatchedCommands 1 "exactly one new charge should be dispatched"
+                    let secondCharge = dispatchedCommands.[0]
+
+                    Expect.equal
+                        secondCharge.Amount
+                        (Imperium.Primitives.Amount.unsafe 4)
+                        "charge for 5 spaces should be 4M"
+
+                    Expect.notEqual secondCharge.BillingId firstBillingId "new charge should have different billing id"
+                    Expect.equal secondCharge.GameId gameId "new charge should have correct GameId"
+                    Expect.equal secondCharge.Nation "France" "new charge should have correct Nation"
+
+                    // Assert: no action determined (new move still pending payment)
+                    let actionEvents2 =
+                        publishedEvents
+                        |> Seq.filter (function
+                            | ActionDetermined _ -> true
+                            | _ -> false)
+                        |> Seq.toList
+
+                    Expect.isEmpty actionEvents2 "no action should be determined for new pending move"
+
+                testCase "move: superseding pending paid move with free move voids charge and completes immediately"
+                <| fun _ ->
+                    // Setup
+                    let load, save = createMockStore ()
+                    let publish, publishedEvents = createMockPublisher ()
+                    let chargeForMovement, dispatchedCommands = createMockCommandDispatcher ()
+                    let voidCharge, voidedCommands = createMockVoidCharge ()
+
+                    let gameId = Guid.NewGuid()
+                    let nations = [| "Germany" |]
+
+                    // Initialize rondel
+                    setToStartingPositions load save publish { GameId = gameId; Nations = nations }
+                    |> ignore
+
+                    publishedEvents.Clear()
+
+                    // First move: Establish starting position (3 spaces, free)
+                    move
+                        load
+                        save
+                        publish
+                        chargeForMovement
+                        voidCharge
+                        { GameId = gameId
+                          Nation = "Germany"
+                          Space = "ManeuverOne" }
+                    |> ignore
+
+                    Expect.contains
+                        publishedEvents
+                        (ActionDetermined
+                            { GameId = gameId
+                              Nation = "Germany"
+                              Action = "Maneuver" })
+                        "first move should determine action"
+
+                    publishedEvents.Clear()
+                    dispatchedCommands.Clear()
+
+                    // Second move: 5 spaces (pending payment) - ManeuverOne to Investor
+                    move
+                        load
+                        save
+                        publish
+                        chargeForMovement
+                        voidCharge
+                        { GameId = gameId
+                          Nation = "Germany"
+                          Space = "Investor" }
+                    |> ignore
+
+                    Expect.hasLength dispatchedCommands 1 "first pending move should dispatch charge"
+                    let firstBillingId = dispatchedCommands.[0].BillingId
+
+                    Expect.equal
+                        dispatchedCommands.[0].Amount
+                        (Imperium.Primitives.Amount.unsafe 4)
+                        "charge for 5 spaces should be 4M"
+
+                    let actionEvents1 =
+                        publishedEvents
+                        |> Seq.filter (function
+                            | ActionDetermined _ -> true
+                            | _ -> false)
+                        |> Seq.toList
+
+                    Expect.isEmpty actionEvents1 "no action should be determined for pending move"
+
+                    publishedEvents.Clear()
+                    dispatchedCommands.Clear()
+
+                    // Third move: 2 spaces (free, should supersede and complete immediately) - ManeuverOne to Factory
+                    move
+                        load
+                        save
+                        publish
+                        chargeForMovement
+                        voidCharge
+                        { GameId = gameId
+                          Nation = "Germany"
+                          Space = "Factory" }
+                    |> ignore
+
+                    // Assert: old charge voided
+                    Expect.hasLength voidedCommands 1 "exactly one void command should be dispatched"
+                    Expect.equal voidedCommands.[0].BillingId firstBillingId "should void the first billing"
+                    Expect.equal voidedCommands.[0].GameId gameId "void command should have correct GameId"
+
+                    // Assert: old move rejected
+                    Expect.contains
+                        publishedEvents
+                        (MoveToActionSpaceRejected
+                            { GameId = gameId
+                              Nation = "Germany"
+                              Space = "Investor" })
+                        "first pending move should be rejected"
+
+                    // Assert: no new charge (free move)
+                    Expect.isEmpty dispatchedCommands "free move should not dispatch charge command"
+
+                    // Assert: action determined for new move (free move completes immediately)
+                    Expect.contains
+                        publishedEvents
+                        (ActionDetermined
+                            { GameId = gameId
+                              Nation = "Germany"
+                              Action = "Factory" })
+                        "free move should determine action immediately despite superseding" ]
+          testList
+              "onInvoicePaid"
+              [ testCase "onInvoicePaid: completes pending movement and publishes ActionDetermined event"
+                <| fun _ ->
+                    // Setup: create mocks
+                    let load, save = createMockStore ()
+                    let publish, publishedEvents = createMockPublisher ()
+                    let chargeForMovement, dispatchedCommands = createMockCommandDispatcher ()
+                    let voidCharge, voidedCommands = createMockVoidCharge ()
+
+                    let gameId = Guid.NewGuid()
+                    let nations = [| "Austria" |]
+
+                    // Setup: initialize rondel
+                    setToStartingPositions load save publish { GameId = gameId; Nations = nations }
+                    |> ignore
+
+                    publishedEvents.Clear()
+
+                    // Setup: establish starting position with first move (free to any space)
+                    move
+                        load
+                        save
+                        publish
+                        chargeForMovement
+                        voidCharge
+                        { GameId = gameId
+                          Nation = "Austria"
+                          Space = "ManeuverOne" }
+                    |> ignore
+
+                    Expect.contains
+                        publishedEvents
+                        (ActionDetermined
+                            { GameId = gameId
+                              Nation = "Austria"
+                              Action = "Maneuver" })
+                        "first move should complete immediately"
+
+                    publishedEvents.Clear()
+                    dispatchedCommands.Clear()
+
+                    // Setup: initiate paid move (5 spaces: ManeuverOne to Investor) - creates pending movement
+                    move
+                        load
+                        save
+                        publish
+                        chargeForMovement
+                        voidCharge
+                        { GameId = gameId
+                          Nation = "Austria"
+                          Space = "Investor" }
+                    |> ignore
+
+                    Expect.hasLength dispatchedCommands 1 "paid move should dispatch charge command"
+                    let billingId = dispatchedCommands.[0].BillingId
+
+                    Expect.equal
+                        dispatchedCommands.[0].Amount
+                        (Imperium.Primitives.Amount.unsafe 4)
+                        "charge for 5 spaces should be 4M"
+
+                    let actionEvents =
+                        publishedEvents
+                        |> Seq.filter (function
+                            | ActionDetermined _ -> true
+                            | _ -> false)
+                        |> Seq.toList
+
+                    Expect.isEmpty actionEvents "no action should be determined until payment confirmed"
+
+                    publishedEvents.Clear()
+                    dispatchedCommands.Clear()
+
+                    // Execute: process payment confirmation
+                    let paymentEvent: Imperium.Contract.Accounting.RondelInvoicePaid =
+                        { GameId = gameId
+                          BillingId = billingId }
+
+                    let result = onInvoicedPaid load save publish paymentEvent
+
+                    // Assert: operation succeeds
+                    Expect.isOk result "payment confirmation should succeed"
+
+                    // Assert: ActionDetermined event published for target space
+                    Expect.contains
+                        publishedEvents
+                        (ActionDetermined
+                            { GameId = gameId
+                              Nation = "Austria"
+                              Action = "Investor" })
+                        "ActionDetermined event should be published after payment confirmation"
+
+                    // Assert: only one event published
+                    Expect.hasLength publishedEvents 1 "only ActionDetermined event should be published"
+
+                    // Assert: no additional charges or voids
+                    Expect.isEmpty dispatchedCommands "no new charges after payment confirmation"
+                    Expect.isEmpty voidedCommands "no voids after successful payment"
+
+                    // Assert: verify state updated - pending movement cleared, position updated
+                    // Subsequent move from Investor (new position) should succeed
+                    publishedEvents.Clear()
+
+                    move
+                        load
+                        save
+                        publish
+                        chargeForMovement
+                        voidCharge
+                        { GameId = gameId
+                          Nation = "Austria"
+                          Space = "Import" }
+                    |> ignore
+
+                    Expect.contains
+                        publishedEvents
+                        (ActionDetermined
+                            { GameId = gameId
+                              Nation = "Austria"
+                              Action = "Import" })
+                        "subsequent move from Investor to Import (1 space) should succeed, confirming position was updated" ] ]


### PR DESCRIPTION
## Summary

This PR applies consistent formatting rules across all F# source and test files to improve code readability and maintainability. No functional changes are introduced - this is purely a stylistic improvement pass.

**Changes include:**
- Normalize type annotation spacing (remove space before colon: `val foo: unit` instead of `val foo : unit`)
- Format multi-field records with one field per line for better readability
- Standardize `Result` type construction with explicit parentheses (`Ok()` instead of `Ok`)
- Improve whitespace consistency in complex expressions, arrays, and function chains
- Enhance indentation in pattern matching and multi-line constructs

**Files affected:**
- `src/Imperium.Web/Program.fs`
- `src/Imperium/Accounting.fsi`
- `src/Imperium/Contract.fs`
- `src/Imperium/Gameplay.fsi`
- `src/Imperium/Primitives.fs`
- `src/Imperium/Rondel.fs`
- `src/Imperium/Rondel.fsi`
- `tests/Imperium.UnitTests/GameplayTests.fs`
- `tests/Imperium.UnitTests/Main.fs`
- `tests/Imperium.UnitTests/RondelTests.fs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced movement validation with improved outcome resolution logic.
  * Introduced modular utilities for space and action handling.
  * Added support for superseding unpaid movements.

* **Style**
  * Applied consistent code formatting across project files.

* **Tests**
  * Updated test suite for comprehensive validation coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->