### PR TITLE
Docs: align agent guidance with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Last verified: 2026-01-03
 ## Agent Priorities
 
 - Follow the three-phase process in `docs/module_design_process.md`: define `.fsi`, write tests, then implement.
-- Keep dependency order consistent: publisher first, then persistence, then external services (e.g., accounting).
+- Keep dependency order consistent: persistence first, then publisher, then external services (e.g., accounting).
 - Prefer minimal public surface; align `.fs` to `.fsi` without widening the API.
 
 ## CQRS & Contract Patterns (anchor details in AGENTS.md)


### PR DESCRIPTION
## Description

Align AGENTS.md and CLAUDE.md with the current Rondel public surface and handler pipeline ordering.

## Type of Change

- [ ] `feat/` - New feature or functionality
- [ ] `fix/` - Bug fix
- [ ] `refactor/` - Code refactoring without changing behavior
- [ ] `test/` - Adding or updating tests
- [x] `docs/` - Documentation updates
- [ ] `chore/` - Maintenance tasks (dependencies, build config, tooling)
- [ ] `perf/` - Performance improvements
- [ ] `style/` - Code style/formatting changes

## Changes Made

- Update AGENTS.md to reflect exposed Rondel types and current decision chain.
- Fix dependency order guidance in CLAUDE.md.

## Testing

- [ ] Unit tests pass locally (`dotnet test`)
- [ ] Build succeeds locally (`dotnet build`)
- [ ] Manual testing completed (if applicable)
- [ ] New tests added for new functionality (if applicable)

## Related Issues

None.

## Breaking Changes

None

## Verification Steps

1. Review AGENTS.md and CLAUDE.md for accuracy against current Rondel API.
2. Confirm no code changes beyond documentation.

## Additional Notes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified move validation logic in the game engine.
  * Updated public API type exposure while maintaining internal abstraction boundaries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->