### PR TITLE
Standardize module file organization in Rondel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
 This file guides Claude Code (claude.ai/code) for this repository. For shared repo facts, module summaries, and commands, see `AGENTS.md`.
-Last verified: 2026-01-03
+Last verified: 2026-01-04
 
 ## Quick Status (last verified: current)
 
@@ -42,4 +42,6 @@ Reasoning: preserves IL shape, avoids unwanted module-load computation, and keep
 - F# defaults: 4-space indent, `PascalCase` for types/modules, `camelCase` for functions.
 - Favor expression-based, pattern-matching code; keep handlers small and injected dependencies explicit.
 - Record construction: Use `{ Field = value }` syntax with type annotation when needed: `let x : RecordType = { ... }`. Never use `RecordType { ... }` - that's not valid F# syntax.
+- Module file organization: Follow the 8-section structure in `AGENTS.md` → "Module File Organization" (Value Types → State → Commands → Events → Dependencies → Transformations → Internal Types → Handlers). Use `// ────...` dividers and `///` XML doc comments.
+- Type inference pitfall: When records share identical fields (e.g., `MoveCommand` and `MoveToActionSpaceRejectedEvent`), F# picks the last-defined type. Add explicit type annotations: `let fn (cmd: MoveCommand) : Result<MoveCommand, string> = ...`
 - Run `dotnet build`/`dotnet test` locally; format with `dotnet fantomas .` (always available via `.config/dotnet-tools.json`).


### PR DESCRIPTION
## Summary

- Reorganize `Rondel.fsi` and `Rondel.fs` into consistent 8-section structure with visual dividers
- Add comprehensive XML doc comments to all public types and functions
- Mark internal handler types with `type internal`
- Add explicit type annotations to fix F# type inference ambiguity
- Document the organization pattern in `AGENTS.md` for other bounded contexts

## Section Structure

| # | Section | Contents |
|---|---------|----------|
| 1 | Value Types & Enumerations | Struct wrappers, DUs, companion modules |
| 2 | Domain State | Persistent state records |
| 3 | Commands | Command DU and records |
| 4 | Events | Event DU and records |
| 5 | Dependencies | Function types for DI |
| 6 | Transformations | `toDomain`, `toContract`, `fromContract` modules |
| 7 | Handlers (Internal Types) | `.fs` only: internal DUs for routing/outcomes |
| 8 | Handlers | Command handlers, then event handlers |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Expanded Rondel system with enhanced movement mechanics, including additional action types and board positions
  - Improved tracking of nation positions and pending movements within game state
  - Richer event structure for better visibility into game state transitions

* **Documentation**
  - Updated module organization and F# coding style guidelines

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->