### PR TITLE
chore: enable GitHub Dependabot for weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,11 @@ updates:
     pull-request-branch-name:
       separator: "-"
     labels:
-      - "dependencies"
+      - "chore"
     open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
 
   # GitHub Actions workflow updates
   - package-ecosystem: "github-actions"
@@ -23,5 +26,8 @@ updates:
     pull-request-branch-name:
       separator: "-"
     labels:
-      - "dependencies"
+      - "chore"
     open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,13 +292,16 @@ The project uses GitHub Actions for automated quality checks on all pull request
 - **NuGet packages**: Weekly updates (Monday 08:00 UTC)
 - **GitHub Actions workflows**: Weekly updates (Monday 08:00 UTC)
 - **Review routing**: Assigned via CODEOWNERS file (no explicit reviewer configuration)
-- **Labels**: All Dependabot PRs automatically tagged with `dependencies`
+- **Labels**: All Dependabot PRs automatically tagged with `chore`
+- **PR limit**: Maximum 3 open PRs per ecosystem to avoid clutter
+- **Commit messages**: All commits prefixed with `chore:` to align with branch naming conventions
 
 **Workflow:**
 
 - Dependabot runs weekly checks for new versions
 - Creates separate PRs for NuGet and Actions updates
 - Each PR includes changelog and upgrade impact summary
+- Commits follow the `chore:` prefix convention
 - Review and merge like any other PR; CODEOWNERS ensures appropriate reviewers are notified
 
 ### Local Development Tools


### PR DESCRIPTION
## Summary

- Enable GitHub Dependabot for automated dependency updates
- Configure weekly scans for NuGet packages and GitHub Actions workflows
- Review routing via CODEOWNERS file (no explicit configuration needed)

## Changes

- Add `.github/dependabot.yml` with NuGet and GitHub Actions ecosystem configuration
- Update `AGENTS.md` with Dependency Management section documenting Dependabot setup and workflow

## Test Plan

- Dependabot will run weekly Monday scans starting next cycle
- Monitor for automatically created PRs labeled `chore`
- Verify review assignment respects CODEOWNERS file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured automated weekly dependency update checks for package ecosystems (NuGet and GitHub Actions) scheduled Mondays at 08:00, with consistent branch naming, labeling as chores, PR limits, and standardized commit messages.

* **Documentation**
  * Added Dependency Management guidance covering update schedules, review workflow and labeling. Updated local development notes to reference Fantomas 7.0.5 and refreshed formatting and restore instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->