### PR TITLE
Refactor: Remove redundant qualifiers and type annotations in RondelTests

### DIFF
--- a/tests/Imperium.UnitTests/RondelTests.fs
+++ b/tests/Imperium.UnitTests/RondelTests.fs
@@ -636,10 +636,7 @@ let tests =
                     Expect.hasLength chargeCommands1 1 "first pending move should dispatch charge"
                     let firstBillingId = chargeCommands1.[0].BillingId
 
-                    Expect.equal
-                        chargeCommands1.[0].Amount
-                        (Amount.unsafe 2)
-                        "charge for 4 spaces should be 2M"
+                    Expect.equal chargeCommands1.[0].Amount (Amount.unsafe 2) "charge for 4 spaces should be 2M"
 
                     let actionEvents1 =
                         publishedEvents
@@ -681,10 +678,7 @@ let tests =
                     Expect.hasLength chargeCommands2 1 "exactly one new charge should be dispatched"
                     let secondCharge = chargeCommands2.[0]
 
-                    Expect.equal
-                        secondCharge.Amount
-                        (Amount.unsafe 4)
-                        "charge for 5 spaces should be 4M"
+                    Expect.equal secondCharge.Amount (Amount.unsafe 4) "charge for 5 spaces should be 4M"
 
                     Expect.notEqual secondCharge.BillingId firstBillingId "new charge should have different billing id"
                     Expect.equal (Id.value secondCharge.GameId) gameId "new charge should have correct GameId"
@@ -750,10 +744,7 @@ let tests =
                     Expect.hasLength chargeCommands1 1 "first pending move should dispatch charge"
                     let firstBillingId = chargeCommands1.[0].BillingId
 
-                    Expect.equal
-                        chargeCommands1.[0].Amount
-                        (Amount.unsafe 4)
-                        "charge for 5 spaces should be 4M"
+                    Expect.equal chargeCommands1.[0].Amount (Amount.unsafe 4) "charge for 5 spaces should be 4M"
 
                     let actionEvents1 =
                         publishedEvents


### PR DESCRIPTION
## Summary
- Remove redundant module qualifiers for types already available through `open` statements
- Remove unnecessary type annotations where F# can infer types from context
- Verify and maintain CLAUDE.md guidance on required type annotations

## Changes
- **Redundant qualifiers removed (14 instances):**
  - `System.Collections.Generic.Dictionary` → `Collections.Generic.Dictionary`
  - `Imperium.Rondel.RondelEvent` → `RondelEvent`
  - `Imperium.Rondel.Action.*` → `Action.*`
  - `Imperium.Primitives.Amount.unsafe` → `Amount.unsafe`

- **Type annotations removed (3 instances):**
  - `load` function: `: RondelState option` return type (inferrable from pattern match)
  - `save` function: `: Result<unit, string>` return type (inferrable from `Ok()`)
  - `spaceToExpectedAction` function: `: Action` return type (inferrable from match expression)

- **Type annotations kept (necessary):**
  - All `MoveCommand` annotations (required due to identical fields with `MoveToActionSpaceRejectedEvent`)
  - `InvoicePaidInboundEvent` annotation (required due to identical fields with `InvoicePaymentFailedInboundEvent`)

## Verification
- ✅ All 16 Rondel tests pass
- ✅ CLAUDE.md guidance on `MoveCommand` type annotations verified and confirmed correct
- ✅ Build succeeds without warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified internal test structure with streamlined API references for improved maintainability.
  * Updated test helper signatures and expectations to align with refactored public API surface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->