### PR TITLE
Simplify rondel type annotations

### DIFF
--- a/src/Imperium/Rondel.fs
+++ b/src/Imperium/Rondel.fs
@@ -1,9 +1,5 @@
 namespace Imperium
 
-open System
-open Imperium.Contract.Accounting
-open Imperium.Contract.Rondel
-
 module Rondel =
     open Imperium.Primitives
     open FsToolkit.ErrorHandling
@@ -88,7 +84,7 @@ module Rondel =
             | Space.ProductionTwo -> "ProductionTwo"
             | Space.ManeuverTwo -> "ManeuverTwo"
 
-        let fromString (s: string) : Result<Space, string> =
+        let fromString s =
             match s with
             | "Investor" -> Ok Space.Investor
             | "Import" -> Ok Space.Import
@@ -296,7 +292,7 @@ module Rondel =
     /// Transforms Domain RondelEvent to Contract type for publication.
     module RondelEvent =
         /// Transform Domain event to Contract event.
-        let toContract (event: RondelEvent) : Contract.Rondel.RondelEvent =
+        let toContract event =
             match event with
             | PositionedAtStart e -> Contract.Rondel.PositionedAtStart { GameId = Id.value e.GameId }
             | ActionDetermined e ->
@@ -476,7 +472,7 @@ module Rondel =
 
             let publishEvents events = events |> List.iter publish |> Ok
 
-            let executeOutboundCommands (commands: RondelOutboundCommand list) =
+            let executeOutboundCommands commands =
                 // setToStartingPositions does not dispatch outbound commands
                 match commands with
                 | [] -> Ok()

--- a/src/Imperium/Rondel.fsi
+++ b/src/Imperium/Rondel.fsi
@@ -2,8 +2,6 @@ namespace Imperium
 
 open System
 open Imperium.Primitives
-open Imperium.Contract.Accounting
-open Imperium.Contract.Rondel
 
 module Rondel =
 


### PR DESCRIPTION
## Summary
- remove a few redundant type annotations in Rondel
- keep disambiguating annotations to satisfy F# inference
- drop unused opens in Rondel.fsi

## Testing
- dotnet build Imperium.sln

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal function signatures and module dependencies to improve code maintainability and organization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->