### PR TITLE
Add Codespaces devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+{
+  "name": "Imperium Codespace",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:1-10.0-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/fish:1": {}
+  },
+  "postCreateCommand": "dotnet tool restore && dotnet restore Imperium.sln",
+  "forwardPorts": [5000, 5001],
+  "mounts": [
+    "source=nuget,target=/home/vscode/.nuget/packages,type=volume"
+  ],
+  "remoteUser": "vscode",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Ionide.ionide-fsharp",
+        "ms-dotnettools.csharp",
+        "anthropic.claude-vscode"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "fish",
+        "terminal.integrated.profiles.linux": {
+          "fish": {
+            "path": "/usr/bin/fish"
+          }
+        },
+        "dotnetAcquisitionExtension.enableTelemetry": false
+      }
+    },
+    "codespaces": {
+      "openFiles": [
+        "AGENTS.md"
+      ]
+    }
+  },
+  "containerEnv": {
+    "DOTNET_CLI_TELEMETRY_OPTOUT": "1"
+  }
+}


### PR DESCRIPTION
## Description

Add a minimal GitHub Codespaces devcontainer using the .NET 10 image, with GitHub CLI, fish shell, Claude Code extension, NuGet cache mount, port forwards, and post-create restore.

## Type of Change

- [ ] feat/ - New feature or functionality
- [ ] fix/ - Bug fix
- [ ] refactor/ - Code refactoring without changing behavior
- [ ] test/ - Adding or updating tests
- [ ] docs/ - Documentation updates
- [x] chore/ - Maintenance tasks (dependencies, build config, tooling)
- [ ] perf/ - Performance improvements
- [ ] style/ - Code style/formatting changes

## Changes Made

- add .devcontainer/devcontainer.json targeting dotnet 10 devcontainer image
- enable GitHub CLI and fish devcontainer features with NuGet cache volume and port forwards
- configure VS Code extensions (Ionide, C# tools, Claude Code) and telemetry opt-out with post-create restores

## Related Issues

None

## Breaking Changes

None

## Verification Steps

1. Create a Codespace from this branch.
2. Verify post-create completes and NuGet restore succeeds.
3. Run `dotnet build` and `dotnet test` successfully.

## Additional Notes

None