### PR TITLE
chore: add VS Code workspace configuration

### DIFF
--- a/imperium.code-workspace
+++ b/imperium.code-workspace
@@ -1,0 +1,146 @@
+{
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "dotnet.defaultSolution": "Imperium.slnx",
+    "editor.formatOnSave": true,
+    "[fsharp]": {
+      "editor.defaultFormatter": "Ionide.ionide-fsharp"
+    },
+    "files.exclude": {
+      "**/bin": true,
+      "**/obj": true
+    },
+    "search.exclude": {
+      "**/bin": true,
+      "**/obj": true
+    },
+    "files.watcherExclude": {
+      "**/bin/**": true,
+      "**/obj/**": true
+    },
+    "terminal.integrated.cwd": "${workspaceFolder}"
+  },
+  "extensions": {
+    "recommendations": [
+      "Ionide.ionide-fsharp",
+      "ms-dotnettools.csdevkit",
+      "ms-dotnettools.csharp",
+      "ms-dotnettools.vscode-dotnet-runtime",
+      "editorconfig.editorconfig",
+      "github.vscode-pull-request-github",
+      "davidanson.vscode-markdownlint"
+    ]
+  },
+  "tasks": {
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "restore",
+        "type": "process",
+        "command": "dotnet",
+        "args": [
+          "restore",
+          "Imperium.slnx"
+        ],
+        "group": "build",
+        "problemMatcher": "$msCompile"
+      },
+      {
+        "label": "build",
+        "type": "process",
+        "command": "dotnet",
+        "args": [
+          "build",
+          "Imperium.slnx",
+          "--no-restore"
+        ],
+        "dependsOn": "restore",
+        "dependsOrder": "sequence",
+        "group": "build",
+        "problemMatcher": "$msCompile"
+      },
+      {
+        "label": "test",
+        "type": "process",
+        "command": "dotnet",
+        "args": [
+          "test",
+          "Imperium.slnx",
+          "--no-build"
+        ],
+        "dependsOn": "build",
+        "dependsOrder": "sequence",
+        "group": "test",
+        "problemMatcher": "$msCompile"
+      },
+      {
+        "label": "run-web",
+        "type": "process",
+        "command": "dotnet",
+        "args": [
+          "run",
+          "--project",
+          "src/Imperium.Web/Imperium.Web.fsproj"
+        ],
+        "group": "none"
+      },
+      {
+        "label": "run-terminal",
+        "type": "process",
+        "command": "dotnet",
+        "args": [
+          "run",
+          "--project",
+          "src/Imperium.Terminal/Imperium.Terminal.fsproj"
+        ],
+        "group": "none"
+      },
+      {
+        "label": "format-check",
+        "type": "process",
+        "command": "dotnet",
+        "args": [
+          "fantomas",
+          "--check",
+          "."
+        ],
+        "group": "test"
+      }
+    ]
+  },
+  "launch": {
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Debug Web",
+        "type": "coreclr",
+        "request": "launch",
+        "program": "dotnet",
+        "args": [
+          "run",
+          "--project",
+          "${workspaceFolder}/src/Imperium.Web/Imperium.Web.fsproj"
+        ],
+        "cwd": "${workspaceFolder}",
+        "console": "integratedTerminal"
+      },
+      {
+        "name": "Debug Terminal",
+        "type": "coreclr",
+        "request": "launch",
+        "program": "dotnet",
+        "args": [
+          "run",
+          "--project",
+          "${workspaceFolder}/src/Imperium.Terminal/Imperium.Terminal.fsproj"
+        ],
+        "cwd": "${workspaceFolder}",
+        "console": "integratedTerminal"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add imperium.code-workspace for a shared team VS Code setup
- set dotnet.defaultSolution to Imperium.slnx
- add common tasks: restore, build, test, run-web, run-terminal, format-check
- add launch profiles for Web and Terminal projects
- include extension recommendations and exclude bin/ and obj/ from explorer/search/watchers

## Validation
- workspace file added and committed as a single focused change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added VSCode workspace configuration with automated development tasks, build and test workflows, debug configurations, and recommended extensions to standardize the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->