### PR TITLE
Add repository configuration as code

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -1,0 +1,15 @@
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "Build, Test & Verify"
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": false
+}

--- a/.github/repo-config.json
+++ b/.github/repo-config.json
@@ -1,0 +1,26 @@
+{
+  "description": "Strategy board game engine for Imperial (Mac Gerdts) — exploring advanced F# patterns, DDD, and CQRS",
+  "homepage": null,
+  "has_issues": true,
+  "has_projects": false,
+  "has_wiki": false,
+  "has_discussions": false,
+  "allow_squash_merge": true,
+  "allow_merge_commit": false,
+  "allow_rebase_merge": false,
+  "allow_auto_merge": false,
+  "delete_branch_on_merge": true,
+  "allow_forking": true,
+  "web_commit_signoff_required": false,
+  "squash_merge_commit_title": "PR_TITLE",
+  "squash_merge_commit_message": "PR_BODY",
+  "topics": [
+    "fsharp",
+    "dotnet",
+    "ddd",
+    "board-game",
+    "domain-driven-design",
+    "cqrs",
+    "imperial"
+  ]
+}

--- a/.github/workflows/enforce-repo-config.yml
+++ b/.github/workflows/enforce-repo-config.yml
@@ -1,0 +1,156 @@
+# Enforces repository configuration as code.
+# Reconciles GitHub settings from checked-in JSON files on a daily schedule,
+# on config file changes, or on manual trigger.
+#
+# Requires a fine-grained PAT stored as REPO_ADMIN_TOKEN with:
+#   - Administration: read/write
+#   - Metadata: read
+
+name: Enforce Repo Configuration
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # Daily at 06:00 UTC
+  push:
+    branches: [master]
+    paths:
+      - ".github/repo-config.json"
+      - ".github/branch-protection.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  enforce:
+    name: Apply Repository Settings
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout config files
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github
+
+      - name: Apply repository settings
+        env:
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+        run: |
+          echo "Applying repository settings..."
+
+          # Extract topics (handled via separate endpoint)
+          TOPICS=$(jq -c '.topics' .github/repo-config.json)
+
+          # Apply general repo settings (exclude topics — different endpoint)
+          jq 'del(.topics)' .github/repo-config.json | \
+            gh api repos/${{ github.repository }} \
+              --method PATCH \
+              --input -
+
+          # Apply topics
+          echo "{\"names\": $TOPICS}" | \
+            gh api repos/${{ github.repository }}/topics \
+              --method PUT \
+              --input -
+
+          echo "Repository settings applied."
+
+      - name: Apply branch protection
+        env:
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+        run: |
+          echo "Applying branch protection for master..."
+
+          gh api repos/${{ github.repository }}/branches/master/protection \
+            --method PUT \
+            --input .github/branch-protection.json
+
+          echo "Branch protection applied."
+
+      - name: Restrict GitHub Actions to verified
+        env:
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+        run: |
+          echo "Restricting Actions to GitHub-owned and verified creators..."
+
+          gh api repos/${{ github.repository }}/actions/permissions \
+            --method PUT \
+            --field enabled=true \
+            --field allowed_actions=selected
+
+          gh api repos/${{ github.repository }}/actions/permissions/selected-actions \
+            --method PUT \
+            --field github_owned_allowed=true \
+            --field verified_allowed=true \
+            --field patterns='[]'
+
+          echo "Actions restrictions applied."
+
+      - name: Enable security features
+        env:
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+        run: |
+          echo "Enabling security features..."
+
+          # Enable Dependabot vulnerability alerts
+          gh api repos/${{ github.repository }}/vulnerability-alerts \
+            --method PUT
+
+          # Enable Dependabot security updates (auto PRs for vulnerabilities)
+          gh api repos/${{ github.repository }}/automated-security-fixes \
+            --method PUT
+
+          # Enable secret scanning
+          gh api repos/${{ github.repository }} \
+            --method PATCH \
+            --input - <<'EOF'
+          {
+            "security_and_analysis": {
+              "secret_scanning": { "status": "enabled" },
+              "secret_scanning_push_protection": { "status": "enabled" }
+            }
+          }
+          EOF
+
+          echo "Security features enabled."
+
+      - name: Verify applied settings
+        env:
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+        run: |
+          echo "## Repo Config Enforcement Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Verify repo settings
+          CURRENT=$(gh api repos/${{ github.repository }} --jq '{
+            description: .description,
+            has_wiki: .has_wiki,
+            has_projects: .has_projects,
+            allow_squash_merge: .allow_squash_merge,
+            allow_merge_commit: .allow_merge_commit,
+            allow_rebase_merge: .allow_rebase_merge,
+            delete_branch_on_merge: .delete_branch_on_merge
+          }')
+          echo "### Repository Settings" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          echo "$CURRENT" | jq . >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Verify topics
+          TOPICS=$(gh api repos/${{ github.repository }}/topics --jq '.names')
+          echo "### Topics" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          echo "$TOPICS" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Verify actions permissions
+          ACTIONS=$(gh api repos/${{ github.repository }}/actions/permissions --jq '{enabled: .enabled, allowed_actions: .allowed_actions}')
+          echo "### Actions Permissions" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          echo "$ACTIONS" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "All settings enforced successfully." >> $GITHUB_STEP_SUMMARY

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly:
+
+1. **Email**: Send details to [bartul.bonacic@live.com](mailto:bartul.bonacic@live.com)
+2. **GitHub Issue**: Open an issue at [github.com/bartul/imperium/issues](https://github.com/bartul/imperium/issues) with the label `security`
+
+Please include:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Any potential impact
+
+I will acknowledge receipt within 48 hours and aim to provide a fix or mitigation plan within 7 days.
+
+## Scope
+
+This policy applies to the latest version of the codebase on the `master` branch.


### PR DESCRIPTION
## Summary

- Define desired repo settings (description, topics, squash-only merge, disable wiki/projects) in `.github/repo-config.json`
- Define branch protection rules (require CI status check, no force push/deletions) in `.github/branch-protection.json`
- Add enforcement workflow (daily cron + push trigger + manual dispatch) that reconciles all settings via GitHub API
- Restrict GitHub Actions to GitHub-owned and verified creators
- Enable secret scanning, push protection, and Dependabot auto-fix PRs
- Add `SECURITY.md` with vulnerability reporting instructions

## Setup required

1. Create a fine-grained PAT with `Administration: read/write` + `Metadata: read` scoped to `bartul/imperium`
2. Add it as a repo secret named `REPO_ADMIN_TOKEN`

## Test plan

- [ ] Create `REPO_ADMIN_TOKEN` secret
- [ ] Trigger workflow manually via Actions tab (`workflow_dispatch`)
- [ ] Verify repo settings applied correctly in job summary report
- [ ] Verify branch protection visible in Settings > Branches (once repo is public)
- [ ] Manually change a setting in UI and confirm next scheduled run reverts it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security policy document with vulnerability reporting procedures, required information for reports, and response timelines (48-hour acknowledgement, 7-day mitigation plan).

* **Chores**
  * Configured branch protection rules and repository governance settings with automated enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->