### PR TITLE
Fix: remove allow_forking from repo config

### DIFF
--- a/.github/repo-config.json
+++ b/.github/repo-config.json
@@ -10,7 +10,6 @@
   "allow_rebase_merge": false,
   "allow_auto_merge": false,
   "delete_branch_on_merge": true,
-  "allow_forking": true,
   "web_commit_signoff_required": false,
   "squash_merge_commit_title": "PR_TITLE",
   "squash_merge_commit_message": "PR_BODY",


### PR DESCRIPTION
## Summary

- Remove `allow_forking` from repo-config.json — this setting is only applicable to org-owned repositories and causes a 422 error on personal repos

## Test plan

- [ ] Trigger enforcement workflow manually and verify it passes