### PR TITLE
Replace email with private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 If you discover a security vulnerability in this project, please report it responsibly:
 
-1. **Email**: Send details to [bartul.bonacic@live.com](mailto:bartul.bonacic@live.com)
-2. **GitHub Issue**: Open an issue at [github.com/bartul/imperium/issues](https://github.com/bartul/imperium/issues) with the label `security`
+1. **Private vulnerability report**: Use the [Security tab](https://github.com/bartul/imperium/security/advisories/new) to submit a private report
+2. **GitHub Issue**: For non-sensitive issues, open an issue at [github.com/bartul/imperium/issues](https://github.com/bartul/imperium/issues) with the label `security`
 
 Please include:
 


### PR DESCRIPTION
## Summary

- Remove personal email from SECURITY.md to avoid spam exposure
- Replace with GitHub's built-in private vulnerability reporting via the Security tab
- Keep GitHub Issues as a secondary channel for non-sensitive reports

## Test plan

- [ ] Verify the private vulnerability reporting link resolves correctly once repo is public

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated vulnerability reporting process with a new private security report option accessible via the Security tab
  * GitHub issue reporting is now reserved for non-sensitive security-labeled issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->