### PR TITLE
Enable private vulnerability reporting in enforcement workflow

### DIFF
--- a/.github/workflows/enforce-repo-config.yml
+++ b/.github/workflows/enforce-repo-config.yml
@@ -112,6 +112,15 @@ jobs:
           gh api repos/${{ github.repository }}/automated-security-fixes \
             --method PUT
 
+          # Enable private vulnerability reporting
+          if gh api repos/${{ github.repository }}/private-vulnerability-reporting \
+            --method PUT 2>&1; then
+            echo "Private vulnerability reporting enabled."
+          else
+            echo "::warning::Private vulnerability reporting requires a public repo. Skipping."
+            echo "- **Private vulnerability reporting**: Skipped (requires public repo)" >> $GITHUB_STEP_SUMMARY
+          fi
+
           # Secret scanning requires public repo or GitHub Advanced Security
           if gh api repos/${{ github.repository }} \
             --method PATCH \


### PR DESCRIPTION
## Summary

- Add private vulnerability reporting enablement to the security features step
- Handles private repo gracefully with a warning (feature requires public repo)
- Once public, the Security tab advisory link in SECURITY.md will work

## Test plan

- [ ] Trigger workflow manually — step should warn and continue on private repo
- [ ] After making repo public, re-run and verify private vulnerability reporting is enabled
- [ ] Verify https://github.com/bartul/imperium/security/advisories/new resolves