### PR TITLE
Render rondel spec states as ASCII boards

### DIFF
--- a/tests/Imperium.UnitTests/Rondel.fs
+++ b/tests/Imperium.UnitTests/Rondel.fs
@@ -66,123 +66,124 @@ let private createContext gameId =
 // Runner
 // ────────────────────────────────────────────────────────────────────────────────
 
-type private BoardCell =
-    | SpaceCell of Space
-    | StartCell
+module private RondelStateFormatting =
+    type BoardCell =
+        | SpaceCell of Space
+        | StartCell
 
-type private CellToken = { Nation: string; Text: string }
+    type CellToken = { Nation: string; Text: string }
 
-let private abbreviateNation =
-    function
-    | "Austria" -> "AH"
-    | "Austria-Hungary" -> "AH"
-    | "France" -> "FR"
-    | "Britain" -> "GB"
-    | "Germany" -> "GE"
-    | "Great Britain" -> "GB"
-    | "Italy" -> "IT"
-    | "Russia" -> "RU"
-    | name when name.Length >= 2 -> name[..1].ToUpperInvariant()
-    | name -> name.ToUpperInvariant()
+    let private abbreviateNation =
+        function
+        | "Austria" -> "AH"
+        | "Austria-Hungary" -> "AH"
+        | "France" -> "FR"
+        | "Britain" -> "GB"
+        | "Germany" -> "GE"
+        | "Great Britain" -> "GB"
+        | "Italy" -> "IT"
+        | "Russia" -> "RU"
+        | name when name.Length >= 2 -> name[..1].ToUpperInvariant()
+        | name -> name.ToUpperInvariant()
 
-let private boardCellName =
-    function
-    | SpaceCell Space.Investor -> "Investor"
-    | SpaceCell Space.Import -> "Import"
-    | SpaceCell Space.ProductionOne
-    | SpaceCell Space.ProductionTwo -> "Production"
-    | SpaceCell Space.ManeuverOne
-    | SpaceCell Space.ManeuverTwo -> "Maneuver"
-    | SpaceCell Space.Taxation -> "Taxation"
-    | SpaceCell Space.Factory -> "Factory"
-    | StartCell -> "Start (o)"
+    let private boardCellName =
+        function
+        | SpaceCell Space.Investor -> "Investor"
+        | SpaceCell Space.Import -> "Import"
+        | SpaceCell Space.ProductionOne
+        | SpaceCell Space.ProductionTwo -> "Production"
+        | SpaceCell Space.ManeuverOne
+        | SpaceCell Space.ManeuverTwo -> "Maneuver"
+        | SpaceCell Space.Taxation -> "Taxation"
+        | SpaceCell Space.Factory -> "Factory"
+        | StartCell -> "Start (o)"
 
-let private boardCellForPosition =
-    function
-    | Some space -> SpaceCell space
-    | None -> StartCell
+    let private boardCellForPosition =
+        function
+        | Some space -> SpaceCell space
+        | None -> StartCell
 
-let private boardRows =
-    [ [ SpaceCell Space.ManeuverTwo
-        SpaceCell Space.Investor
-        SpaceCell Space.Import ]
-      [ SpaceCell Space.ProductionTwo; StartCell; SpaceCell Space.ProductionOne ]
-      [ SpaceCell Space.Factory
-        SpaceCell Space.Taxation
-        SpaceCell Space.ManeuverOne ] ]
+    let private boardRows =
+        [ [ SpaceCell Space.ManeuverTwo
+            SpaceCell Space.Investor
+            SpaceCell Space.Import ]
+          [ SpaceCell Space.ProductionTwo; StartCell; SpaceCell Space.ProductionOne ]
+          [ SpaceCell Space.Factory
+            SpaceCell Space.Taxation
+            SpaceCell Space.ManeuverOne ] ]
 
-let private addToken cell token tokensByCell =
-    let existing = tokensByCell |> Map.tryFind cell |> Option.defaultValue []
-    tokensByCell |> Map.add cell (token :: existing)
+    let private addToken cell token tokensByCell =
+        let existing = tokensByCell |> Map.tryFind cell |> Option.defaultValue []
+        tokensByCell |> Map.add cell (token :: existing)
 
-let private cellContent tokensByCell cell =
-    tokensByCell
-    |> Map.tryFind cell
-    |> Option.defaultValue []
-    |> List.sortBy (fun token -> token.Nation)
-    |> List.map (fun token -> token.Text)
-    |> String.concat " "
+    let private cellContent tokensByCell cell =
+        tokensByCell
+        |> Map.tryFind cell
+        |> Option.defaultValue []
+        |> List.sortBy (fun token -> token.Nation)
+        |> List.map (fun token -> token.Text)
+        |> String.concat " "
 
-let private center width (text: string) =
-    let padding = max 0 (width - text.Length)
-    let left = padding / 2
-    let right = padding - left
-    String.replicate left " " + text + String.replicate right " "
+    let private center width (text: string) =
+        let padding = max 0 (width - text.Length)
+        let left = padding / 2
+        let right = padding - left
+        String.replicate left " " + text + String.replicate right " "
 
-let private renderBoardRow width cells tokensByCell =
-    let renderLine renderCell =
-        cells |> List.map renderCell |> String.concat "|" |> (fun line -> $"|{line}|")
+    let private renderBoardRow width cells tokensByCell =
+        let renderLine renderCell =
+            cells |> List.map renderCell |> String.concat "|" |> (fun line -> $"|{line}|")
 
-    let titleLine = renderLine (fun cell -> $" {center width (boardCellName cell)} ")
+        let titleLine = renderLine (fun cell -> $" {center width (boardCellName cell)} ")
 
-    let contentLine =
-        renderLine (fun cell -> $" {center width (cellContent tokensByCell cell)} ")
+        let contentLine =
+            renderLine (fun cell -> $" {center width (cellContent tokensByCell cell)} ")
 
-    [ titleLine; contentLine ]
+        [ titleLine; contentLine ]
 
-let private formatRondelState (state: RondelState option) : string =
-    match state with
-    | None -> "No rondel state"
-    | Some state ->
-        let tokensByCell =
-            state.NationPositions
-            |> Map.toList
-            |> List.fold
-                (fun currentTokens (nation, currentSpace) ->
-                    let abbreviation = abbreviateNation nation
-                    let originCell = boardCellForPosition currentSpace
+    let format (state: RondelState option) : string =
+        match state with
+        | None -> "No rondel state"
+        | Some state ->
+            let tokensByCell =
+                state.NationPositions
+                |> Map.toList
+                |> List.fold
+                    (fun currentTokens (nation, currentSpace) ->
+                        let abbreviation = abbreviateNation nation
+                        let originCell = boardCellForPosition currentSpace
 
-                    match state.PendingMovements |> Map.tryFind nation with
-                    | Some pending ->
-                        currentTokens
-                        |> addToken originCell { Nation = nation; Text = $"{abbreviation}->" }
-                        |> addToken (SpaceCell pending.TargetSpace) { Nation = nation; Text = $"->{abbreviation}" }
-                    | None -> currentTokens |> addToken originCell { Nation = nation; Text = abbreviation })
-                Map.empty
+                        match state.PendingMovements |> Map.tryFind nation with
+                        | Some pending ->
+                            currentTokens
+                            |> addToken originCell { Nation = nation; Text = $"{abbreviation}->" }
+                            |> addToken (SpaceCell pending.TargetSpace) { Nation = nation; Text = $"->{abbreviation}" }
+                        | None -> currentTokens |> addToken originCell { Nation = nation; Text = abbreviation })
+                    Map.empty
 
-        let cellWidth =
-            boardRows
-            |> List.collect id
-            |> List.collect (fun cell -> [ boardCellName cell; cellContent tokensByCell cell ])
-            |> List.map String.length
-            |> List.max
-            |> max 12
+            let cellWidth =
+                boardRows
+                |> List.collect id
+                |> List.collect (fun cell -> [ boardCellName cell; cellContent tokensByCell cell ])
+                |> List.map String.length
+                |> List.max
+                |> max 12
 
-        let border =
-            [ 1..3 ]
-            |> List.map (fun _ -> String.replicate (cellWidth + 2) "-")
-            |> String.concat "+"
-            |> fun line -> $"+{line}+"
+            let border =
+                [ 1..3 ]
+                |> List.map (fun _ -> String.replicate (cellWidth + 2) "-")
+                |> String.concat "+"
+                |> fun line -> $"+{line}+"
 
-        let boardLines =
-            boardRows
-            |> List.collect (fun row -> border :: renderBoardRow cellWidth row tokensByCell)
+            let boardLines =
+                boardRows
+                |> List.collect (fun row -> border :: renderBoardRow cellWidth row tokensByCell)
 
-        String.concat
-            "\n"
-            (boardLines
-             @ [ border
-                 "Legend: FR = current position, FR-> = pending move origin, ->FR = pending move target" ])
+            String.concat
+                "\n"
+                (boardLines
+                 @ [ border
+                     "Legend: FR = current position, FR-> = pending move origin, ->FR = pending move target" ])
 
 let private runner =
     { SpecRunner.empty with
@@ -196,7 +197,7 @@ let private runner =
                 match ctx.Store.TryGetValue(ctx.GameId) with
                 | true, state -> Some state
                 | false, _ -> None)
-        FormatState = Some formatRondelState }
+        FormatState = Some RondelStateFormatting.format }
 
 // ────────────────────────────────────────────────────────────────────────────────
 // Helpers

--- a/tests/Imperium.UnitTests/Rondel.fs
+++ b/tests/Imperium.UnitTests/Rondel.fs
@@ -179,11 +179,7 @@ module private RondelStateFormatting =
                 boardRows
                 |> List.collect (fun row -> border :: renderBoardRow cellWidth row tokensByCell)
 
-            String.concat
-                "\n"
-                (boardLines
-                 @ [ border
-                     "Legend: FR = current position, FR-> = pending move origin, ->FR = pending move target" ])
+            String.concat "\n" (boardLines @ [ border ])
 
 let private runner =
     { SpecRunner.empty with

--- a/tests/Imperium.UnitTests/Rondel.fs
+++ b/tests/Imperium.UnitTests/Rondel.fs
@@ -96,7 +96,7 @@ module private RondelStateFormatting =
         | SpaceCell Space.ManeuverTwo -> "Maneuver"
         | SpaceCell Space.Taxation -> "Taxation"
         | SpaceCell Space.Factory -> "Factory"
-        | StartCell -> "Start (o)"
+        | StartCell -> "↻"
 
     let private boardCellForPosition =
         function

--- a/tests/Imperium.UnitTests/Rondel.fs
+++ b/tests/Imperium.UnitTests/Rondel.fs
@@ -66,6 +66,124 @@ let private createContext gameId =
 // Runner
 // ────────────────────────────────────────────────────────────────────────────────
 
+type private BoardCell =
+    | SpaceCell of Space
+    | StartCell
+
+type private CellToken = { Nation: string; Text: string }
+
+let private abbreviateNation =
+    function
+    | "Austria" -> "AH"
+    | "Austria-Hungary" -> "AH"
+    | "France" -> "FR"
+    | "Britain" -> "GB"
+    | "Germany" -> "GE"
+    | "Great Britain" -> "GB"
+    | "Italy" -> "IT"
+    | "Russia" -> "RU"
+    | name when name.Length >= 2 -> name[..1].ToUpperInvariant()
+    | name -> name.ToUpperInvariant()
+
+let private boardCellName =
+    function
+    | SpaceCell Space.Investor -> "Investor"
+    | SpaceCell Space.Import -> "Import"
+    | SpaceCell Space.ProductionOne
+    | SpaceCell Space.ProductionTwo -> "Production"
+    | SpaceCell Space.ManeuverOne
+    | SpaceCell Space.ManeuverTwo -> "Maneuver"
+    | SpaceCell Space.Taxation -> "Taxation"
+    | SpaceCell Space.Factory -> "Factory"
+    | StartCell -> "Start (o)"
+
+let private boardCellForPosition =
+    function
+    | Some space -> SpaceCell space
+    | None -> StartCell
+
+let private boardRows =
+    [ [ SpaceCell Space.ManeuverTwo
+        SpaceCell Space.Investor
+        SpaceCell Space.Import ]
+      [ SpaceCell Space.ProductionTwo; StartCell; SpaceCell Space.ProductionOne ]
+      [ SpaceCell Space.Factory
+        SpaceCell Space.Taxation
+        SpaceCell Space.ManeuverOne ] ]
+
+let private addToken cell token tokensByCell =
+    let existing = tokensByCell |> Map.tryFind cell |> Option.defaultValue []
+    tokensByCell |> Map.add cell (token :: existing)
+
+let private cellContent tokensByCell cell =
+    tokensByCell
+    |> Map.tryFind cell
+    |> Option.defaultValue []
+    |> List.sortBy (fun token -> token.Nation)
+    |> List.map (fun token -> token.Text)
+    |> String.concat " "
+
+let private center width (text: string) =
+    let padding = max 0 (width - text.Length)
+    let left = padding / 2
+    let right = padding - left
+    String.replicate left " " + text + String.replicate right " "
+
+let private renderBoardRow width cells tokensByCell =
+    let renderLine renderCell =
+        cells |> List.map renderCell |> String.concat "|" |> (fun line -> $"|{line}|")
+
+    let titleLine = renderLine (fun cell -> $" {center width (boardCellName cell)} ")
+
+    let contentLine =
+        renderLine (fun cell -> $" {center width (cellContent tokensByCell cell)} ")
+
+    [ titleLine; contentLine ]
+
+let private formatRondelState (state: RondelState option) : string =
+    match state with
+    | None -> "No rondel state"
+    | Some state ->
+        let tokensByCell =
+            state.NationPositions
+            |> Map.toList
+            |> List.fold
+                (fun currentTokens (nation, currentSpace) ->
+                    let abbreviation = abbreviateNation nation
+                    let originCell = boardCellForPosition currentSpace
+
+                    match state.PendingMovements |> Map.tryFind nation with
+                    | Some pending ->
+                        currentTokens
+                        |> addToken originCell { Nation = nation; Text = $"{abbreviation}->" }
+                        |> addToken (SpaceCell pending.TargetSpace) { Nation = nation; Text = $"->{abbreviation}" }
+                    | None -> currentTokens |> addToken originCell { Nation = nation; Text = abbreviation })
+                Map.empty
+
+        let cellWidth =
+            boardRows
+            |> List.collect id
+            |> List.collect (fun cell -> [ boardCellName cell; cellContent tokensByCell cell ])
+            |> List.map String.length
+            |> List.max
+            |> max 12
+
+        let border =
+            [ 1..3 ]
+            |> List.map (fun _ -> String.replicate (cellWidth + 2) "-")
+            |> String.concat "+"
+            |> fun line -> $"+{line}+"
+
+        let boardLines =
+            boardRows
+            |> List.collect (fun row -> border :: renderBoardRow cellWidth row tokensByCell)
+
+        String.concat
+            "\n"
+            (boardLines
+             @ [ border
+                 "Legend: FR = current position, FR-> = pending move origin, ->FR = pending move target" ])
+
 let private runner =
     { SpecRunner.empty with
         Execute = fun ctx cmd -> execute ctx.Deps cmd |> Async.RunSynchronously
@@ -77,7 +195,8 @@ let private runner =
             Some(fun ctx ->
                 match ctx.Store.TryGetValue(ctx.GameId) with
                 | true, state -> Some state
-                | false, _ -> None) }
+                | false, _ -> None)
+        FormatState = Some formatRondelState }
 
 // ────────────────────────────────────────────────────────────────────────────────
 // Helpers

--- a/tests/Imperium.UnitTests/Spec.fs
+++ b/tests/Imperium.UnitTests/Spec.fs
@@ -140,7 +140,8 @@ type SpecRunner<'ctx, 'seed, 'state, 'cmd, 'evt> =
       ClearEvents: 'ctx -> unit
       ClearCommands: 'ctx -> unit
       SeedState: 'ctx -> 'seed -> unit
-      CaptureState: ('ctx -> 'state) option }
+      CaptureState: ('ctx -> 'state) option
+      FormatState: ('state -> string) option }
 
 module SpecRunner =
     let empty<'ctx, 'seed, 'state, 'cmd, 'evt> : SpecRunner<'ctx, 'seed, 'state, 'cmd, 'evt> =
@@ -149,7 +150,8 @@ module SpecRunner =
           ClearEvents = fun _ -> ()
           ClearCommands = fun _ -> ()
           SeedState = fun _ _ -> ()
-          CaptureState = None }
+          CaptureState = None
+          FormatState = None }
 
 // ────────────────────────────────────────────────────────────────────────────────
 // Runner Helpers

--- a/tests/Imperium.UnitTests/SpecMarkdown.fs
+++ b/tests/Imperium.UnitTests/SpecMarkdown.fs
@@ -124,12 +124,12 @@ let private renderTableRows rows =
 
     [ "| | |"; "| --- | --- |" ] @ bodyRows
 
-let private renderSection title stateText rows =
-    [ $"##### %s{title}"; ""; "```text"; stateText; "```"; "" ]
+let private renderSection weight title stateText rows =
+    [ renderHeader weight title; ""; "```text"; stateText; "```"; "" ]
     @ if List.isEmpty rows then [] else renderTableRows rows
 
-let private renderActionSection title rows =
-    [ $"##### %s{title}"; "" ]
+let private renderActionSection weight title rows =
+    [ renderHeader weight title; "" ]
     @ if List.isEmpty rows then [] else renderTableRows rows
 
 let toMarkdown
@@ -161,16 +161,18 @@ let toMarkdown
             let result = if expectation.Predicate context then "✅" else "❌"
             result, expectation.Description)
 
-    let specHeader = renderHeader (childHeader options.ParentHeader) $"📋 %s{spec.Name}"
+    let specHeaderWeight = childHeader options.ParentHeader
+    let sectionHeaderWeight = childHeader specHeaderWeight
+    let specHeader = renderHeader specHeaderWeight $"📋 %s{spec.Name}"
 
     String.concat
         Environment.NewLine
         ([ specHeader; "" ]
-         @ renderSection "Given" initialStateText givenRows
+         @ renderSection sectionHeaderWeight "Given" initialStateText givenRows
          @ [ "" ]
-         @ renderActionSection "When" whenRows
+         @ renderActionSection sectionHeaderWeight "When" whenRows
          @ [ "" ]
-         @ renderSection "Then" finalStateText thenRows
+         @ renderSection sectionHeaderWeight "Then" finalStateText thenRows
          @ [ "" ])
 
 let toMarkdownDocument options runner specifications =

--- a/tests/Imperium.UnitTests/SpecMarkdown.fs
+++ b/tests/Imperium.UnitTests/SpecMarkdown.fs
@@ -107,6 +107,11 @@ let rec private formatValue (value: obj) (valueType: Type) =
 
 let private formatState (state: 'state) = formatValue (box state) typeof<'state>
 
+let private renderState (runner: SpecRunner<'ctx, 'seed, 'state, 'cmd, 'evt>) (state: 'state) =
+    match runner.FormatState with
+    | Some formatter -> formatter state
+    | None -> formatState state
+
 let private formatAction action =
     match action with
     | Execute command -> Some(sprintf "Command `%A`" command)
@@ -128,14 +133,14 @@ let toMarkdown
 
     let initialStateText =
         runner.CaptureState
-        |> Option.map (fun capture -> capture context |> formatState)
+        |> Option.map (fun capture -> capture context |> renderState runner)
         |> Option.defaultValue "_no state capture_"
 
     runActions runner context spec.Actions
 
     let finalStateText =
         runner.CaptureState
-        |> Option.map (fun capture -> capture context |> formatState)
+        |> Option.map (fun capture -> capture context |> renderState runner)
         |> Option.defaultValue "_no state capture_"
 
     let givenActionItems =
@@ -144,17 +149,15 @@ let toMarkdown
     let givenActionRows =
         match givenActionItems with
         | [] -> []
-        | _ -> captionRows "" givenActionItems
+        | _ -> captionRows "Given" givenActionItems
 
     let whenItems = spec.Actions |> List.choose formatAction |> List.map escapeCell
 
     let thenItems =
-        [ $"State `{finalStateText}`" |> escapeCell
-          yield!
-              spec.Expectations
-              |> List.map (fun expectation ->
-                  let result = if expectation.Predicate context then "✅" else "❌"
-                  $"%s{result} %s{expectation.Description}" |> escapeCell) ]
+        spec.Expectations
+        |> List.map (fun expectation ->
+            let result = if expectation.Predicate context then "✅" else "❌"
+            $"%s{result} %s{expectation.Description}" |> escapeCell)
 
     let specHeader = renderHeader (childHeader options.ParentHeader) $"📋 %s{spec.Name}"
 
@@ -162,13 +165,17 @@ let toMarkdown
         Environment.NewLine
         ([ specHeader
            ""
+           "**Initial state**"
+           "```text"
+           initialStateText
+           "```"
+           ""
            "| Step | Details |"
-           "| --- | --- |"
-           sprintf "| Given | State %s |" (escapeCell $"`{initialStateText}`") ]
+           "| --- | --- |" ]
          @ givenActionRows
          @ captionRows "When" whenItems
          @ captionRows "Then" thenItems
-         @ [ "" ])
+         @ [ ""; "**Final state**"; "```text"; finalStateText; "```"; "" ])
 
 let toMarkdownDocument options runner specifications =
     specifications

--- a/tests/Imperium.UnitTests/SpecMarkdown.fs
+++ b/tests/Imperium.UnitTests/SpecMarkdown.fs
@@ -112,17 +112,27 @@ let private renderState (runner: SpecRunner<'ctx, 'seed, 'state, 'cmd, 'evt>) (s
     | Some formatter -> formatter state
     | None -> formatState state
 
-let private formatAction action =
+let private formatActionRow action =
     match action with
-    | Execute command -> Some(sprintf "Command `%A`" command)
-    | Handle event -> Some(sprintf "Event `%A`" event)
+    | Execute command -> Some("Command", sprintf "`%A`" command)
+    | Handle event -> Some("Event", sprintf "`%A`" event)
 
-let private captionRows caption items =
-    match items with
-    | [] -> [ sprintf "| %s | %s |" caption (escapeCell "_none_") ]
-    | head :: tail ->
-        [ $"| %s{caption} | %s{head} |" ]
-        @ (tail |> List.map (fun item -> $"| | %s{item} |"))
+let private renderTableRows rows =
+    let bodyRows = rows |> List.map (fun (left, right) -> $"| {escapeCell left} | {escapeCell right} |")
+
+    [ "| | |"; "| --- | --- |" ] @ bodyRows
+
+let private renderSection title stateText rows =
+    [ $"##### %s{title}"
+      ""
+      "```text"
+      stateText
+      "```"
+      "" ]
+    @ if List.isEmpty rows then [] else renderTableRows rows
+
+let private renderActionSection title rows =
+    [ $"##### %s{title}"; "" ] @ if List.isEmpty rows then [] else renderTableRows rows
 
 let toMarkdown
     (options: MarkdownRenderOptions)
@@ -143,21 +153,15 @@ let toMarkdown
         |> Option.map (fun capture -> capture context |> renderState runner)
         |> Option.defaultValue "_no state capture_"
 
-    let givenActionItems =
-        spec.GivenActions |> List.choose formatAction |> List.map escapeCell
+    let givenRows = spec.GivenActions |> List.choose formatActionRow
 
-    let givenActionRows =
-        match givenActionItems with
-        | [] -> []
-        | _ -> captionRows "Given" givenActionItems
+    let whenRows = spec.Actions |> List.choose formatActionRow
 
-    let whenItems = spec.Actions |> List.choose formatAction |> List.map escapeCell
-
-    let thenItems =
+    let thenRows =
         spec.Expectations
         |> List.map (fun expectation ->
             let result = if expectation.Predicate context then "✅" else "❌"
-            $"%s{result} %s{expectation.Description}" |> escapeCell)
+            result, expectation.Description)
 
     let specHeader = renderHeader (childHeader options.ParentHeader) $"📋 %s{spec.Name}"
 
@@ -165,17 +169,13 @@ let toMarkdown
         Environment.NewLine
         ([ specHeader
            ""
-           "**Initial state**"
-           "```text"
-           initialStateText
-           "```"
-           ""
-           "| Step | Details |"
-           "| --- | --- |" ] 
-         @ givenActionRows
-         @ captionRows "When" whenItems
-         @ captionRows "Then" thenItems
-         @ [ ""; "**Final state**"; "```text"; finalStateText; "```"; "" ])
+           ]
+         @ renderSection "Given" initialStateText givenRows
+         @ [ "" ]
+         @ renderActionSection "When" whenRows
+         @ [ "" ]
+         @ renderSection "Then" finalStateText thenRows
+         @ [ "" ])
 
 let toMarkdownDocument options runner specifications =
     specifications

--- a/tests/Imperium.UnitTests/SpecMarkdown.fs
+++ b/tests/Imperium.UnitTests/SpecMarkdown.fs
@@ -114,25 +114,23 @@ let private renderState (runner: SpecRunner<'ctx, 'seed, 'state, 'cmd, 'evt>) (s
 
 let private formatActionRow action =
     match action with
-    | Execute command -> Some("Command", sprintf "`%A`" command)
-    | Handle event -> Some("Event", sprintf "`%A`" event)
+    | Execute command -> Some("👉", sprintf "`%A`" command)
+    | Handle event -> Some("🔔", sprintf "`%A`" event)
 
 let private renderTableRows rows =
-    let bodyRows = rows |> List.map (fun (left, right) -> $"| {escapeCell left} | {escapeCell right} |")
+    let bodyRows =
+        rows
+        |> List.map (fun (left, right) -> $"| {escapeCell left} | {escapeCell right} |")
 
     [ "| | |"; "| --- | --- |" ] @ bodyRows
 
 let private renderSection title stateText rows =
-    [ $"##### %s{title}"
-      ""
-      "```text"
-      stateText
-      "```"
-      "" ]
+    [ $"##### %s{title}"; ""; "```text"; stateText; "```"; "" ]
     @ if List.isEmpty rows then [] else renderTableRows rows
 
 let private renderActionSection title rows =
-    [ $"##### %s{title}"; "" ] @ if List.isEmpty rows then [] else renderTableRows rows
+    [ $"##### %s{title}"; "" ]
+    @ if List.isEmpty rows then [] else renderTableRows rows
 
 let toMarkdown
     (options: MarkdownRenderOptions)
@@ -167,9 +165,7 @@ let toMarkdown
 
     String.concat
         Environment.NewLine
-        ([ specHeader
-           ""
-           ]
+        ([ specHeader; "" ]
          @ renderSection "Given" initialStateText givenRows
          @ [ "" ]
          @ renderActionSection "When" whenRows

--- a/tests/Imperium.UnitTests/SpecMarkdown.fs
+++ b/tests/Imperium.UnitTests/SpecMarkdown.fs
@@ -171,7 +171,7 @@ let toMarkdown
            "```"
            ""
            "| Step | Details |"
-           "| --- | --- |" ]
+           "| --- | --- |" ] 
          @ givenActionRows
          @ captionRows "When" whenItems
          @ captionRows "Then" thenItems


### PR DESCRIPTION
## Summary
- add pluggable spec state formatting so spec markdown can opt into custom renderers
- render spec initial and final state in fenced text blocks instead of inline table cells
- add a rondel-specific ASCII board renderer for captured rondel state, including pending paid moves

## Testing
- dotnet fantomas .
- dotnet build
- dotnet test
- dotnet run --no-build --project tests/Imperium.UnitTests/Imperium.UnitTests.fsproj -- --render-spec-markdown

Closes #112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reporting with improved formatting and display of game board state in test outputs
  * Restructured test documentation to clearly separate and display initial and final states
  * Improved visual clarity of game state representation throughout test execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->