### PR TITLE
Sync docs with actual implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ An experimental project exploring **AI-assisted software development** technique
 This codebase serves as a showcase for several design patterns and development techniques:
 
 - **F# signature files (`.fsi`) as enforceable API contracts** — public surface is defined in signature files; implementations cannot widen it, giving compile-time boundary enforcement
-- **CQRS with command/event routers** — separate `execute` (commands) and `handle` (inbound events) routers as single entry points, with dedicated query handlers
+- **CQRS with command/event routers** — separate `execute` (commands) and `handle` (inbound events) routers as single entry points (Rondel), with dedicated query handlers
 - **Dependency injection via records of functions** — no IoC container; dependencies are plain `Async<_>` function values bundled in records, enabling implicit `CancellationToken` propagation
 - **Pure business logic separated from IO** — handler internals return `(state, events, commands)` tuples; a shared `materialize` function sequences all side effects
-- **Bounded context isolation through Contract DTOs** — cross-BC communication uses plain primitive types (`Guid`, `string`, `int`); transformation modules validate at each boundary
-- **`Decision<'State,'Outcome>` monad** — a custom computation expression for chaining validation steps in business rule pipelines
-- **CE-based declarative test specs** — [Simple.Testing](https://github.com/gregoryyoung/Simple.Testing)-inspired `on`/`when_`/`expect` syntax where each expectation becomes its own isolated test case
+- **Bounded context isolation through Contract DTOs** — cross-BC communication uses plain primitive types (`Guid`, `string`) and shared value types (`Amount`); transformation modules validate at each boundary
+- **`Decision<'State,'Outcome>` type** — a bind/resolve pipeline for chaining validation steps in business rule pipelines
+- **CE-based declarative test specs** — [Simple.Testing](https://github.com/gregoryyoung/Simple.Testing)-inspired `on`/`state`/`given_command`/`given_event`/`preserve`/`when_command`/`when_event`/`expect` syntax where each expectation becomes its own isolated test case
 - **Three-phase module development process** — define `.fsi` interface first, write failing tests against it, then implement until green
 - **`MailboxProcessor` for serialized writes** — terminal app uses F# agents to serialize state mutations per bounded context while allowing concurrent reads
 
@@ -29,11 +29,11 @@ See [docs/architecture.md](docs/architecture.md) for detailed design documentati
 
 ```
 src/
-  Imperium/              Core domain library (Rondel, Accounting, Contracts, Primitives)
+  Imperium/              Core domain library (Rondel, Accounting, Gameplay, Contracts, Primitives)
   Imperium.Terminal/     Terminal UI app using Terminal.Gui v2
   Imperium.Web/          ASP.NET Core web host (placeholder)
 tests/
-  Imperium.UnitTests/    90 tests (Expecto + CE-based specs)
+  Imperium.UnitTests/    99 tests (Expecto + CE-based specs)
 docs/                    Design documents and official game rules
 ```
 
@@ -62,21 +62,32 @@ dotnet run --project src/Imperium.Terminal
 
 ## CE-Based Specs
 
-Bounded-context behavior tests in this repository use computation expression-based specifications with a readable flow: `on` (context), `when_` (commands/events), `expect` (boolean predicates).  
+Bounded-context behavior tests in this repository use computation expression-based specifications with a readable flow: `on` (context), `when_command`/`when_event` (actions), `expect` (boolean predicates).  
 Each `expect` runs as an isolated test case that replays the full scenario setup.
 
 ```fsharp
-let private specs =
-    [ spec "charging a nation for paid movement confirms payment" {
-          on createContext
-          when_
-              [ ChargeNationForRondelMovement
-                    { GameId = gameId
-                      Nation = "France"
-                      Amount = Amount.unsafe 4
-                      BillingId = billingId }
-                |> Execute ]
-          expect "payment is confirmed" hasPaymentConfirmed
+let private rondelSpecs =
+    let gameId = Id.newId ()
+    let nations = Set.ofList [ "France"; "Austria" ]
+    let spec = specOn (fun () -> createContext gameId)
+
+    [ spec "paying a pending movement completes it and determines action" {
+          state (
+              RondelState.create gameId (Set.ofList [ "Austria" ])
+              |> RondelState.withNationPosition "Austria" Space.ManeuverOne
+              |> RondelState.withPendingMove "Austria" Space.Investor invoicePaidBillingId
+          )
+
+          when_event (InvoicePaid { GameId = gameId; BillingId = invoicePaidBillingId })
+          when_command (Move { GameId = gameId; Nation = "Austria"; Space = Space.Import })
+
+          expect
+              "action is determined from pending movement"
+              (hasExactEvent (ActionDetermined { GameId = gameId; Nation = "Austria"; Action = Action.Investor }))
+
+          expect
+              "subsequent move uses starts from updated position"
+              (hasExactEvent (ActionDetermined { GameId = gameId; Nation = "Austria"; Action = Action.Import }))
       } ]
 ```
 
@@ -86,7 +97,7 @@ let private specs =
 |---|---|
 | **Language** | F# on .NET 10 |
 | **Terminal UI** | Terminal.Gui v2 |
-| **Testing** | Expecto, FsCheck |
+| **Testing** | Expecto |
 | **Utilities** | FsToolkit.ErrorHandling |
 | **Formatting** | Fantomas |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,9 +88,9 @@ Execution flow per expectation:
 
 1. Build context via `on`
 2. Seed state from inline `state` if provided
-3. Run setup `actions`
+3. Run setup `given_command`/`given_event` actions
 4. Clear setup side-effects unless `preserve` is enabled
-5. Run `when_` actions
+5. Run `when_command`/`when_event` actions
 6. Evaluate one `expect` predicate
 
 Each `expect` is materialized as its own test case and reruns the full flow above, providing deterministic isolation between expectations.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ The domain is split into isolated bounded contexts that communicate only through
 - **Accounting** — Processes charges and publishes payment results. Currently a skeleton that auto-approves all charges.
 - **Gameplay** — Game orchestration, scoring, turn management. Not yet implemented.
 
-Cross-BC communication uses `Contract.*` DTOs with plain primitive types (`Guid`, `string`, `int`). Domain types never leak across boundaries.
+Cross-BC communication uses `Contract.*` DTOs with plain primitive types (`Guid`, `string`) and shared value types (`Amount`). Domain types never leak across boundaries.
 
 ## CQRS Pattern
 
@@ -43,12 +43,8 @@ This separates pure domain logic from IO, making business rules testable without
 Dependencies are records of `Async<_>` functions — no IoC container:
 
 ```fsharp
-type RondelDependencies = {
-    Load:     Id -> Async<RondelState option>
-    Save:     RondelState -> Async<Result<unit, string>>
-    Publish:  RondelEvent -> Async<unit>
-    Dispatch: RondelOutboundCommand -> Async<Result<unit, string>>
-}
+type RondelDependencies =
+    { Load: LoadRondelState; Save: SaveRondelState; Publish: PublishRondelEvent; Dispatch: DispatchOutboundCommand }
 ```
 
 `CancellationToken` flows implicitly through the `Async` context without explicit threading.
@@ -84,8 +80,8 @@ Conceptually, a spec contains:
 
 - **Context factory (`on`)** — builds fresh test context per expectation
 - **Optional seed (`state`)** — injects initial state when needed
-- **Optional setup actions (`actions`)** — preconditions executed before `when_`
-- **Main actions (`when_`)** — commands/events under test
+- **Optional setup actions (`given_command`/`given_event`)** — preconditions executed before the main actions
+- **Main actions (`when_command`/`when_event`)** — commands/events under test
 - **Expectations (`expect`)** — pure `'ctx -> bool` predicates
 
 Execution flow per expectation:
@@ -117,7 +113,7 @@ type IBus =
     abstract Subscribe<'T> : ('T -> Async<unit>) -> unit
 ```
 
-Internally uses `ConcurrentDictionary<Type, ResizeArray<'T -> Async<unit>>>` — typed handler lists avoid boxing at the API boundary. Events use domain types directly in-process (no Contract round-trip).
+Internally uses `ConcurrentDictionary<Type, obj>` with generic `HandlerStore<'T>` wrappers — per-type immutable handler snapshots make publish safe under concurrent subscription. Events use domain types directly in-process (no Contract round-trip).
 
 ### Breaking Circular Dependencies
 
@@ -125,9 +121,14 @@ F# prohibits circular module references. Cross-BC command dispatch uses thunk in
 
 ```fsharp
 let rec rondelHost: Lazy<RondelHost> =
-    lazy (RondelHost.create store bus (fun () cmd -> accountingHost.Value.Execute cmd))
-and accountingHost: Lazy<AccountingHost> =
-    lazy (AccountingHost.create bus)
+    lazy
+        (RondelHost.create store bus (fun () cmd ->
+            async {
+                do! accountingHost.Value.Execute cmd
+                return Ok()
+            }))
+
+and accountingHost: Lazy<AccountingHost> = lazy (AccountingHost.create bus)
 ```
 
 ### Events vs Commands


### PR DESCRIPTION
## Summary
- Fix test count (90 → 99), update CE spec example and syntax description, correct Decision type characterization, qualify CQRS scope, add Gameplay to project structure, fix Contract DTO types, and remove unused FsCheck from tech stack in README
- Fix RondelDependencies code sample style, spec CE operation names, Bus internals description, and composition root code sample in architecture.md
- Fix stale `actions`/`when_` terminology in spec execution flow steps

## Test plan
- [ ] Verify all code samples in docs match actual source
- [ ] Confirm no behavioral changes (docs-only PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify test specification syntax with expanded clauses and refined examples.
  * Refined architecture documentation for cross-bounded-context communication patterns and dependency handling.
  * Updated project structure documentation reflecting expanded modules and increased test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->