### PR TITLE
chore: add Dependabot cooldown settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "08:00"
+    cooldown:
+      default-days: 3
+      semver-major-days: 14
+      semver-minor-days: 3
+      semver-patch-days: 1
     pull-request-branch-name:
       separator: "-"
     labels:
@@ -23,6 +28,11 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "08:00"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     pull-request-branch-name:
       separator: "-"
     labels:


### PR DESCRIPTION
## Summary

Adds Dependabot cooldown windows for automated dependency updates:

- NuGet uses a fast-moving profile: 1 day for patches, 3 days for minors, 14 days for majors, with a 3-day default.
- GitHub Actions uses the standard recommended profile: 3 days for patches, 7 days for minors, 30 days for majors, with a 7-day default.

## Impact

This reduces the chance of adopting a newly published package or action immediately while keeping routine updates moving on the existing weekly schedule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to adjust update scheduling intervals for package and action dependencies.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->