### PR TITLE
Fix deploy workflow to target .NET 10 and the web project explicitly

### DIFF
--- a/.github/workflows/master_imperium-game.yml
+++ b/.github/workflows/master_imperium-game.yml
@@ -16,14 +16,13 @@ jobs:
       - name: Set up .NET Core
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: '9.x'
-          include-prerelease: true
+          dotnet-version: '10.x'
 
       - name: Build with dotnet
-        run: dotnet build --configuration Release
+        run: dotnet build src/Imperium.Web/Imperium.Web.fsproj --configuration Release
 
       - name: dotnet publish
-        run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        run: dotnet publish src/Imperium.Web/Imperium.Web.fsproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary
- Bumps the Azure deploy workflow's `dotnet-version` from `9.x` to `10.x` — every project in the solution targets `net10.0`, so the deploy job was pulling a mismatched SDK.
- Scopes `dotnet build`/`dotnet publish` to `src/Imperium.Web/Imperium.Web.fsproj` explicitly, since the solution now has three fsproj files and the previous unscoped commands left MSBuild to pick one implicitly.

Addresses finding F1-A from #176.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated build and deployment workflow to use .NET 10.
  * Standardized release builds and publishing for the web application.
  * Updated the Azure Web Apps deployment action configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->